### PR TITLE
Add comprehensive refactor planning documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,4 @@ Thumbs.db
 *tmp*
 
 # Claude Code configuration
-CLAUDE.local.md
 .claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,13 +22,11 @@ This is a SystemVerilog Language Server Protocol (LSP) implementation with a mod
 ### Core Components
 
 **LSP Core Library (`lsp/`)**
-
 - Language-agnostic LSP protocol implementation built on JSON-RPC
 - Base `LspServer` class with virtual handlers for LSP lifecycle and features
 - Document management and ASIO coroutine-based async operations
 
 **Slangd Server (`slangd/`)**
-
 - SystemVerilog LSP server extending the generic `LspServer`
 - Uses Slang library for SystemVerilog parsing and semantic analysis
 - Core managers handle configuration, documents, and workspace operations
@@ -52,7 +50,6 @@ This is a SystemVerilog Language Server Protocol (LSP) implementation with a mod
 ### Coding Standards
 
 Follow Google C++ Style Guide with these specifics:
-
 - Use C++23 features, avoid macros
 - ASIO coroutines with strands for synchronization (no mutexes/futures)
 - `std::expected` for error handling over exceptions
@@ -67,3 +64,57 @@ Follow Google C++ Style Guide with these specifics:
 - Repository-wide symbol indexing (infrastructure complete, not yet exposed via LSP)
 
 The architecture enables future language servers (e.g. VHDL) to reuse the generic `lsp` core.
+
+## Branch Naming Conventions
+
+Use these prefixes for branch names:
+- `feature/` - for new features
+- `bugfix/` - for bug fixes
+- `docs/` - for documentation changes  
+- `chore/` - for maintenance tasks
+
+## Git Commit Message Rules
+
+1. **First line**: Short summary (50-72 characters max)
+2. **Body**: Use bullet points with `-` for multiple changes/reasons
+   - Wrap lines at 72 characters
+   - Explain what and why, not how
+
+**Example format:**
+```
+Short summary under 72 chars
+
+- First change or reason explained
+- Second change or reason explained
+```
+
+**Note**: Claude Code attribution goes in PR descriptions, not individual commits
+
+## Pull Request Rules
+
+**Title:**
+- Short summary (50-72 chars max)
+- Match branch naming style if helpful
+
+**Description Structure:**
+```markdown
+## Summary
+- Brief bullet points of main changes
+- Use `-` for consistency
+
+## Additional sections as needed:
+- Changes (for complex PRs)
+- Breaking Changes (if applicable)  
+- Notes (context, decisions, etc.)
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+```
+
+**Guidelines:**
+- Always include Summary
+- Add other sections only when they add value
+- Keep it concise and relevant to the specific change
+
+## Configuration Notes
+
+- Use `CLAUDE.local.md` for project instructions (not `CLAUDE.md`)

--- a/CONFIG-ANALYSIS.md
+++ b/CONFIG-ANALYSIS.md
@@ -1,0 +1,281 @@
+# ConfigManager Architecture Analysis
+
+## Overview
+
+This analysis documents the current ConfigManager architecture in the slangd project to understand the dependencies and data flow for a planned refactoring from config-driven to auto-discovery mode.
+
+## 1. ConfigManager Integration Points
+
+### 1.1 Core Architecture
+
+The ConfigManager is at the heart of the slangd initialization flow:
+
+```
+main.cpp → SlangdLspServer → ConfigManager → {DocumentManager, WorkspaceManager} → FeatureProviders
+```
+
+### 1.2 File Locations
+
+- **Header**: `/home/hankhsu/workspace/c++/slangd/include/slangd/core/config_manager.hpp`
+- **Implementation**: `/home/hankhsu/workspace/c++/slangd/src/slangd/core/config_manager.cpp`
+- **Config File**: `/home/hankhsu/workspace/c++/slangd/include/slangd/core/slangd_config_file.hpp`
+
+### 1.3 Direct Dependencies
+
+ConfigManager is **directly required** by:
+
+1. **SlangdLspServer** (`slangd_lsp_server.cpp:40-49`)
+   - Created during `OnInitialize()` 
+   - Passed to both DocumentManager and WorkspaceManager
+   - Used for config file change handling
+
+2. **DocumentManager** (`document_manager.hpp:22`, `document_manager.cpp:24`)
+   - Takes `std::shared_ptr<ConfigManager>` in constructor
+   - Uses config for preprocessing options during parsing
+
+3. **WorkspaceManager** (`workspace_manager.hpp:26`, `workspace_manager.cpp:20`)
+   - Takes `std::shared_ptr<ConfigManager>` in constructor
+   - Uses config for file discovery and workspace scanning
+
+## 2. Manager Dependencies Details
+
+### 2.1 DocumentManager Dependencies
+
+**File**: `src/slangd/core/document_manager.cpp`
+
+**Usage Points**:
+- **Lines 40-45**: Gets preprocessor defines and include directories for Slang parsing
+  ```cpp
+  for (const auto& define : config_manager_->GetDefines()) {
+    pp_options.predefines.push_back(define);
+  }
+  for (const auto& include_dir : config_manager_->GetIncludeDirectories()) {
+    pp_options.additionalIncludePaths.emplace_back(include_dir.Path());
+  }
+  ```
+
+**Critical Functionality**:
+- **Preprocessor Defines**: Used to set macros for SystemVerilog compilation
+- **Include Directories**: Used to resolve `include statements in SystemVerilog files
+- **Parsing Options**: Both are fed into Slang's `PreprocessorOptions`
+
+### 2.2 WorkspaceManager Dependencies
+
+**File**: `src/slangd/core/workspace_manager.cpp`
+
+**Usage Points**:
+- **Line 138**: `auto all_files = config_manager_->GetSourceFiles()` - Core file discovery
+- **Lines 277-285**: File filtering during workspace changes based on config
+- **TestingFactory**: Creates default ConfigManager for test environments (line 39)
+
+**Critical Functionality**:
+- **File Discovery**: Primary source of which files to include in workspace
+- **File Filtering**: Determines which file changes are relevant
+- **Workspace Scanning**: Drives the initial workspace indexing process
+
+### 2.3 Feature Providers (Indirect Dependencies)
+
+Feature providers don't directly depend on ConfigManager but rely on it indirectly through DocumentManager and WorkspaceManager:
+
+- **DiagnosticsProvider**: Uses DocumentManager's parsed compilation (with config-based preprocessor options)
+- **DefinitionProvider**: Uses both managers which depend on ConfigManager
+- **SymbolsProvider**: Uses both managers which depend on ConfigManager
+
+## 3. Current Initialization Flow
+
+### 3.1 LSP Server Startup Flow
+
+1. **main.cpp**: Creates SlangdLspServer with executor and logger
+2. **OnInitialize()** (`slangd_lsp_server.cpp:27-82`):
+   ```cpp
+   // Create ConfigManager first
+   config_manager_ = std::make_shared<ConfigManager>(executor_, workspace_uri);
+   
+   // Load configuration (may return false if no config found)
+   co_await config_manager_->LoadConfig(workspace_uri);
+   
+   // Create managers with ConfigManager dependency
+   document_manager_ = std::make_shared<DocumentManager>(executor_, config_manager_);
+   workspace_manager_ = std::make_shared<WorkspaceManager>(executor_, workspace_uri, config_manager_);
+   
+   // Create feature providers (indirect dependency)
+   definition_provider_ = std::make_unique<DefinitionProvider>(document_manager_, workspace_manager_);
+   // ... other providers
+   ```
+
+3. **OnInitialized()** (`slangd_lsp_server.cpp:84-129`):
+   - Triggers `workspace_manager_->ScanWorkspace()` 
+   - Registers file system watchers
+   - Background workspace indexing begins
+
+### 3.2 Config Loading Behavior
+
+**Success Path** (`config_manager.cpp:22-53`):
+- Looks for `.slangd` file in workspace root
+- Parses YAML configuration using yaml-cpp
+- Logs configuration details (includes, defines, files, file lists)
+- Returns `true`
+
+**No Config Path**:
+- **LoadConfig()** returns `false` but doesn't fail
+- **ConfigManager** continues with `config_.reset()` (empty optional)
+- Fallback behavior kicks in for file discovery and settings
+
+### 3.3 Config Change Handling
+
+**File Watcher** (`slangd_lsp_server.cpp:326-360`):
+- Watches `**/.slangd` files via LSP file system watcher
+- Calls `config_manager_->HandleConfigFileChange()` on changes
+- If config updated, triggers `workspace_manager_->ScanWorkspace()` 
+- Rescans entire workspace with new settings
+
+## 4. Configuration Data Usage Analysis
+
+### 4.1 SlangdConfigFile Structure
+
+**File**: `slangd_config_file.hpp`
+
+```yaml
+# Example .slangd configuration
+FileLists:
+  Paths: ["project.f", "testbench.f"] 
+  Absolute: false
+
+Files: 
+  - "src/main.sv"
+  - "src/utils.sv"
+
+IncludeDirs:
+  - "include/"
+  - "vendor/include/"
+
+Defines:
+  - "SIMULATION"
+  - "DEBUG=1"
+```
+
+### 4.2 Data Usage by Component
+
+| **Config Data** | **Used By** | **Purpose** | **Criticality** | **Auto-Discovery Potential** |
+|---|---|---|---|---|
+| **Files** | WorkspaceManager | Direct file list for compilation | High | **Yes** - recursive file scanning |
+| **FileLists** (.f files) | WorkspaceManager | File list references | High | **Partial** - could scan for .f files |
+| **IncludeDirs** | DocumentManager | Preprocessor include paths | High | **Yes** - scan for common include patterns |
+| **Defines** | DocumentManager | Preprocessor macros | Medium | **No** - requires explicit specification |
+
+### 4.3 Fallback Behavior (Auto-Discovery Mode)
+
+**When no config exists** (`config_manager.cpp`):
+
+1. **GetSourceFiles()** (Lines 93-131):
+   - Falls back to `FindSystemVerilogFilesInDirectory(workspace_root_)`
+   - Recursively scans workspace for `.sv`, `.svh`, `.v`, `.vh` files
+   - Uses `IsSystemVerilogFile()` from `path_utils.cpp:24-26`
+
+2. **GetIncludeDirectories()** (Lines 133-154):
+   - Falls back to **ALL directories in workspace** via `recursive_directory_iterator`
+   - Very broad but safe approach
+
+3. **GetDefines()** (Lines 156-165):
+   - Falls back to **empty list** 
+   - No auto-discovery for preprocessor defines
+
+## 5. Refactoring Impact Assessment
+
+### 5.1 Big-Bang Refactor Requirements
+
+To remove ConfigManager dependencies entirely:
+
+1. **DocumentManager Changes**:
+   - Remove `std::shared_ptr<ConfigManager>` parameter from constructor
+   - Replace `config_manager_->GetDefines()` with auto-discovered or default defines
+   - Replace `config_manager_->GetIncludeDirectories()` with auto-discovered includes
+   - **Impact**: Moderate - need alternative source for preprocessing options
+
+2. **WorkspaceManager Changes**:
+   - Remove `std::shared_ptr<ConfigManager>` parameter from constructor  
+   - Replace `config_manager_->GetSourceFiles()` with direct auto-discovery
+   - Remove config-based file filtering in `HandleFileCreated()`
+   - **Impact**: High - core file discovery logic change
+
+3. **SlangdLspServer Changes**:
+   - Remove ConfigManager creation and lifecycle management
+   - Remove config file change handling
+   - Update manager constructors to not require ConfigManager
+   - **Impact**: Moderate - simplification of initialization
+
+4. **Test Infrastructure**:
+   - Update all test cases that create ConfigManager instances
+   - Replace config-based test setups with direct file specification
+   - **Impact**: Low - tests should become simpler
+
+### 5.2 Alternative Auto-Discovery Approaches
+
+1. **File Discovery**:
+   - **Current**: Config specifies files OR fallback to recursive scan
+   - **Proposed**: Always use recursive scan with smart filtering
+   - **Enhancement**: Respect `.gitignore`, common build directories
+
+2. **Include Directory Discovery**:
+   - **Current**: Config specifies OR all directories fallback
+   - **Proposed**: Heuristic-based discovery (common patterns like `include/`, `inc/`, `src/`)
+   - **Enhancement**: Parse existing files for `include paths
+
+3. **Preprocessor Defines**:
+   - **Current**: Config specifies OR empty fallback  
+   - **Proposed**: Empty by default (safest approach)
+   - **Future**: Parse common build files (Makefiles, etc.) for defines
+
+### 5.3 Migration Strategy
+
+**Phase 1 - Preparation**:
+- Add auto-discovery logic to ConfigManager as fallback enhancement
+- Test auto-discovery thoroughly with existing config-based systems
+- Ensure feature parity with current fallback behavior
+
+**Phase 2 - Big-Bang Refactor**:
+- Remove ConfigManager dependency from constructors
+- Move auto-discovery logic directly into managers
+- Update all call sites and tests simultaneously  
+- Remove ConfigManager and SlangdConfigFile classes
+
+**Phase 3 - Enhancement**:
+- Improve auto-discovery heuristics
+- Add user-configurable auto-discovery settings via LSP workspace configuration
+- Implement smarter include directory detection
+
+### 5.4 Risk Assessment
+
+**High Risk**:
+- **Preprocessing behavior changes**: Different include paths or defines could break user projects
+- **File discovery differences**: Auto-discovery might include/exclude different files than config
+
+**Medium Risk**:
+- **Performance impact**: Recursive directory scanning vs. explicit file lists
+- **Test compatibility**: Extensive test suite updates required
+
+**Low Risk**:  
+- **LSP protocol compatibility**: No changes to LSP interface
+- **Feature functionality**: Core language features should remain unchanged
+
+## 6. Recommendations
+
+### 6.1 Implementation Order
+
+1. **Start with WorkspaceManager**: File discovery is the most isolated change
+2. **Then DocumentManager**: Preprocessing options have clear fallback strategies  
+3. **Finally SlangdLspServer**: Remove config management infrastructure
+4. **Update tests last**: Once core changes are stabilized
+
+### 6.2 Preservation Strategy
+
+Consider keeping ConfigManager as an **optional** enhancement rather than removing entirely:
+- Auto-discovery by default
+- Optional config file support for advanced users
+- Gradual migration path instead of big-bang removal
+
+This would reduce risk while providing the auto-discovery benefits for most users.
+
+---
+
+**Analysis completed**: Ready for refactoring planning phase.

--- a/IMPLEMENTATION-PROGRESS.md
+++ b/IMPLEMENTATION-PROGRESS.md
@@ -1,0 +1,124 @@
+# Implementation Progress: Config-Driven to Auto-Discovery Refactor
+
+## Status Overview
+- **Started**: 2025-09-08
+- **Current Phase**: Planning & Setup
+- **Overall Progress**: 0% (Planning complete, implementation not started)
+
+## Phase 1: Setup & ConfigManager Refactor (0% Complete)
+
+### 1.1 Slang Integration Setup
+- [ ] **Convert Slang to git submodule** (Current: Bazel external dependency)
+  - [ ] Add Slang as git submodule
+  - [ ] Update Bazel BUILD files to use local Slang
+  - [ ] Verify build still works
+  - [ ] Document submodule workflow
+
+### 1.2 Make ConfigManager Optional (0/4 Complete)
+- [ ] **SlangdLspServer changes** (`src/slangd/core/slangd_lsp_server.cpp:40-50`)
+  - [ ] Modify `OnInitialize()` to conditionally create ConfigManager
+  - [ ] Check for `.slangd` file existence before creating ConfigManager
+  - [ ] Pass nullable ConfigManager to other managers
+  
+- [ ] **DocumentManager changes** (`src/slangd/core/document_manager.cpp:24`)
+  - [ ] Make ConfigManager parameter optional in constructor
+  - [ ] Add fallback logic for defines/includeDirs when ConfigManager is null
+  - [ ] Update `ParseWithCompilation()` to handle null config
+  
+- [ ] **WorkspaceManager changes** (`src/slangd/core/workspace_manager.cpp`)
+  - [ ] Make ConfigManager parameter optional in constructor  
+  - [ ] Implement auto-discovery file scanning (may already exist as fallback)
+  - [ ] Ensure workspace scanning works without config
+  
+- [ ] **Update all manager constructors**
+  - [ ] Change ConfigManager from `std::shared_ptr<ConfigManager>` to `std::shared_ptr<ConfigManager> = nullptr`
+  - [ ] Update all call sites
+
+### 1.3 Test Basic Auto-Discovery (0/3 Complete)
+- [ ] **Create test workspace** without `.slangd` file
+- [ ] **Verify basic functionality** works (file discovery, parsing, basic diagnostics)
+- [ ] **Document any issues** found with auto-discovery mode
+
+## Phase 2: Slang LSP Mode Implementation (0% Complete)
+
+### 2.1 Slang Analysis & Understanding (0/5 Complete)
+- [ ] **Study Slang compilation modes**
+  - [ ] Understand current LintMode implementation
+  - [ ] Identify where LintMode breaks symbol indexing
+  - [ ] Map out compilation pipeline and visitor interaction
+  
+- [ ] **Analyze current symbol indexing issues**
+  - [ ] Reproduce submodule instantiation segfaults
+  - [ ] Identify specific AST nodes missing in LintMode
+  - [ ] Document exact failure modes
+
+- [ ] **Research Slang visitor patterns**
+  - [ ] Understand `slang::ast::makeVisitor` usage in `SymbolIndex::FromCompilation`
+  - [ ] Identify which visitor callbacks fail with incomplete AST
+  - [ ] Document required AST completeness for symbol indexing
+
+- [ ] **Study Slang compilation flags**
+  - [ ] Map out all `CompilationFlags` options
+  - [ ] Understand interaction between flags and AST generation
+  - [ ] Identify minimal requirements for visitor-compatible AST
+
+- [ ] **Design LSP mode requirements**
+  - [ ] Define what "partial compilation" means for LSP needs
+  - [ ] Specify which symbols must be preserved vs can be missing
+  - [ ] Plan graceful degradation for unresolved references
+
+### 2.2 LSP Mode Implementation (0/4 Complete)
+- [ ] **Create LSP compilation mode in Slang**
+  - [ ] Add `CompilationFlags::LspMode` flag
+  - [ ] Implement logic to preserve uninstantiated module symbols
+  - [ ] Ensure AST visitor compatibility
+  
+- [ ] **Modify symbol resolution behavior**
+  - [ ] Allow unresolved module instantiations (don't fail compilation)
+  - [ ] Generate placeholder symbols for missing modules
+  - [ ] Maintain symbol linking for available definitions
+
+- [ ] **Test LSP mode extensively**
+  - [ ] Verify no segfaults with incomplete codebases
+  - [ ] Validate symbol indexing works with missing dependencies
+  - [ ] Performance test on large workspaces
+
+- [ ] **Integration with slangd**
+  - [ ] Update `DocumentManager::ParseWithCompilation` to use LSP mode
+  - [ ] Verify `SymbolIndex::FromCompilation` works correctly
+  - [ ] Test end-to-end LSP features (definitions, symbols, completion)
+
+## Phase 3: Integration & Polish (0% Complete)
+
+### 3.1 Feature Validation (0/5 Complete)
+- [ ] **Diagnostics provider** works with auto-discovery
+- [ ] **Symbol provider** handles mixed resolved/unresolved code  
+- [ ] **Definition provider** gracefully handles missing targets
+- [ ] **Completion provider** works with partial compilation
+- [ ] **Cross-file navigation** functions correctly
+
+### 3.2 Performance & Scalability (0/3 Complete)
+- [ ] **Benchmark startup time** with large workspaces
+- [ ] **Memory usage analysis** for auto-discovery vs config mode
+- [ ] **Optimization** of file scanning and indexing
+
+### 3.3 Documentation & Examples (0/3 Complete)
+- [ ] **Update README** to emphasize zero-config experience
+- [ ] **Create examples** showing auto-discovery vs config usage
+- [ ] **Migration guide** for existing `.slangd` users
+
+## Current Blockers
+- None (in planning phase)
+
+## Next Immediate Actions
+1. **Set up Slang submodule** - enables deep analysis of internals
+2. **Create simple test case** - workspace with mixed design/verification code to validate approach
+3. **Begin ConfigManager refactor** - start with making it optional
+
+## Notes & Decisions
+- **ConfigManager strategy**: Make optional, keep for defines/includeDirs (don't remove entirely)
+- **Slang integration**: Use git submodule for easier analysis and patching
+- **Testing approach**: Create representative mixed codebase for validation
+
+---
+*This document tracks implementation progress against the plan outlined in `REFACTOR-PLAN.local.md`*

--- a/REFACTOR-PLAN.md
+++ b/REFACTOR-PLAN.md
@@ -1,0 +1,156 @@
+# Slangd Refactor Plan: Config-Driven to Auto-Discovery
+
+## Background & Problem Statement
+
+### Current Issues
+- **Config dependency problem**: Language server requires `.slangd` config files with top modules and filelists to function
+- **User experience**: Users want "open workspace and it works" like other LSP servers (clangd, TypeScript, etc.)
+- **Mixed codebase challenge**: Projects have design (Slang-clean) and verification (not Slang-clean) code - current approach forces config-based file filtering
+- **LSP best practices**: Modern language servers default to auto-discovery with optional configuration
+
+### Goal
+Transform slangd from **config-required** to **config-optional** ("zero-config by default") while maintaining functionality.
+
+## Architectural Analysis
+
+### Current Flow
+```
+LSP Server → ConfigManager (required) → {DocumentManager, WorkspaceManager} → Feature Providers
+```
+
+### Target Flow  
+```
+LSP Server → Auto-discovery + ConfigManager (optional hints) → Managers → Feature Providers
+```
+
+## Implementation Options Analysis
+
+### Option A: Big Bang vs Gradual Migration
+
+**Big Bang Approach** ✅ **CHOSEN**
+- **Pros**: Clean result, MVP-focused, no dual complexity, leverage early-stage flexibility
+- **Cons**: Higher short-term risk
+- **Decision rationale**: Early stage project, no production users, speed matters for MVP
+
+**Gradual Migration** ❌ **REJECTED**  
+- **Pros**: Lower risk
+- **Cons**: Temporary complexity, slower delivery, maintaining two systems
+
+### Option B: Slang Integration Strategy
+
+**Option 1: Fork Slang + LSP Mode** ✅ **CHOSEN FOR BEST-IN-CLASS**
+- **Pros**: 
+  - 90% functionality already working
+  - Complete SystemVerilog specification coverage
+  - Battle-tested by enterprise users
+  - One-time learning investment in Slang internals
+  - Contribute back to SV ecosystem
+- **Cons**: 
+  - Learning curve for Slang internals
+  - Fork maintenance overhead
+- **Decision rationale**: For best possible language server, leverage decades of compiler expertise
+
+**Option 2: Syntax-Tree Only** ❌ **REJECTED FOR FINAL PRODUCT**
+- **Pros**: Full control, incremental development
+- **Cons**: Reimplementing SystemVerilog semantics = infinite scope, guaranteed bugs
+- **Note**: Could be viable for MVP but not sustainable long-term
+
+**Option 3: Keep Current Approach** ❌ **REJECTED**
+- **Issue**: LintMode + AST visitor = broken symbol indexing
+- **Root cause**: Slang's visitor not designed for partial compilation
+- **Result**: Missing symbols, segfaults, incomplete linking
+
+## SystemVerilog vs C++ Complexity
+
+### C++ Model (Simple)
+```cpp
+#include "path/to/file.h"  // Explicit file path
+// Every symbol from explicit includes
+// Self-contained compilation units
+```
+
+### SystemVerilog Model (Complex)  
+```systemverilog
+import package_name::*;    // No path - global namespace!
+my_module inst();          // No import needed - global namespace!
+```
+
+**Key insight**: SystemVerilog requires **global symbol discovery** - can't do single-file compilation like C++.
+
+**Solution**: Two-phase approach
+1. **Phase 1**: Parse all `.sv` files, extract global symbol table
+2. **Phase 2**: Per-file analysis using global symbol context
+
+## Current Technical Challenges
+
+### Core Issue: LintMode vs Visitor Mismatch
+```cpp
+// DocumentManager uses LintMode to avoid compilation failures
+comp_options.flags |= slang::ast::CompilationFlags::LintMode;
+
+// But SymbolIndex::FromCompilation expects full AST
+// Result: Missing submodule instances → visitor crashes/incomplete
+```
+
+### Specific Problems
+- Submodule instantiations ignored in LintMode
+- Port bindings never initialized  
+- AST visitor segfaults on incomplete trees
+- Symbol linking breaks for unresolved modules
+
+## Configuration Strategy: clangd Model
+
+**Learning from clangd** (C++ and SystemVerilog are both compiled languages):
+- ✅ **Auto-discover**: Source files (`.cpp`, `.h` → `.sv`, `.v`)
+- ❌ **Require config**: Include directories and defines (via `.clangd`, `compile_commands.json` → `.slangd`)
+
+**Refined approach**:
+- **Remove (auto-discover)**: File lists, top modules
+- **Keep (explicit config)**: Include directories (`includeDirs`), preprocessor defines  
+- **Rationale**: File discovery = easy automation; include paths/defines = project-specific, hard to guess
+
+## Implementation Plan
+
+### Phase 1: Remove ConfigManager Dependencies
+1. Modify `SlangdLspServer::OnInitialize()` - remove required ConfigManager creation
+2. Update `DocumentManager` constructor - make ConfigManager optional
+3. Update `WorkspaceManager` constructor - make ConfigManager optional  
+4. Implement fallback auto-discovery logic (already exists in fallback paths)
+
+### Phase 2: Add LSP Mode to Slang
+1. **Study Slang internals**: Understand compilation modes, visitor patterns
+2. **Identify patch points**: Where LintMode breaks symbol indexing
+3. **Implement LSP mode**: Partial compilation that works with AST visitors
+   - Allow unresolved symbol references (don't fail compilation)
+   - Generate AST nodes for uninstantiated modules (enable visitor traversal)
+   - Preserve symbol linking even with missing dependencies
+4. **Test extensively**: Ensure no regressions in existing functionality
+
+### Phase 3: Integration & Testing
+1. Update `SymbolIndex::FromCompilation` to use LSP mode
+2. Comprehensive testing with mixed design/verification codebases
+3. Performance validation on large projects
+4. Update documentation and examples
+
+## Decision Record
+
+**Date**: 2025-09-08  
+**Decision**: Proceed with **Big Bang refactor** using **Fork Slang + LSP Mode** approach  
+**Participants**: Project maintainer + Claude analysis  
+**Rationale**: 
+- Early stage project allows for breaking changes
+- MVP speed is priority  
+- Best long-term approach for production-quality language server
+- Leverage existing Slang expertise rather than reimplementing SystemVerilog semantics
+
+## Next Steps
+1. Create detailed technical analysis of Slang compilation modes
+2. Identify specific patch requirements for LSP mode
+3. Set up Slang fork and development environment  
+4. Begin incremental implementation starting with DocumentManager changes
+
+## References
+- Current architecture documented in `CONFIG-ANALYSIS.local.md`
+- SystemVerilog specification challenges
+- clangd configuration model
+- Industry LSP best practices


### PR DESCRIPTION
## Summary
- Add CONFIG-ANALYSIS.md documenting current architecture and ConfigManager dependencies
- Add REFACTOR-PLAN.md with decision rationale for auto-discovery approach  
- Add IMPLEMENTATION-PROGRESS.md for tracking refactor progress
- Convert CLAUDE.local.md to CLAUDE.md for cross-machine consistency
- Update gitignore to remove CLAUDE.local.md reference

## Documentation Added
This adds the complete analysis and planning for the major refactor from config-driven to auto-discovery mode.

🤖 Generated with [Claude Code](https://claude.ai/code)