### PR TITLE
Implement overlay session infrastructure with LRU caching

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,9 @@ Use these prefixes for branch names:
 2. **Body**: Use bullet points with `-` for multiple changes/reasons
    - Wrap lines at 72 characters
    - Explain what and why, not how
+3. **Focus on changes**: Describe what is changed, not project phases or steps
+   - Avoid mentioning "Phase 1A", "Step 2", etc.
+   - Focus on concrete technical changes and their purpose
 
 **Example format:**
 

--- a/include/slangd/core/global_catalog.hpp
+++ b/include/slangd/core/global_catalog.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "slangd/utils/canonical_path.hpp"
+
+namespace slangd {
+
+// Forward declaration of package/interface metadata structures
+// These will be implemented in Phase 2 when GlobalCatalog is populated
+struct PackageInfo {
+  std::string name;
+  CanonicalPath file_path;
+  // Future: additional metadata
+};
+
+struct InterfaceInfo {
+  std::string name;
+  CanonicalPath file_path;
+  // Future: additional metadata
+};
+
+// Empty interface for Global Catalog - designed for future implementation
+// Phase 2 will populate this with actual compilation metadata
+// For now, OverlaySession can accept nullptr and work in single-file mode
+class GlobalCatalog {
+ public:
+  GlobalCatalog() = default;
+  GlobalCatalog(const GlobalCatalog&) = delete;
+  GlobalCatalog(GlobalCatalog&&) = delete;
+  auto operator=(const GlobalCatalog&) -> GlobalCatalog& = delete;
+  auto operator=(GlobalCatalog&&) -> GlobalCatalog& = delete;
+  virtual ~GlobalCatalog() = default;
+
+  // Future Phase 2 interface - for now returns empty
+  [[nodiscard]] virtual auto GetPackages() const
+      -> const std::vector<PackageInfo>& {
+    static const std::vector<PackageInfo> kEmpty;
+    return kEmpty;
+  }
+
+  [[nodiscard]] virtual auto GetInterfaces() const
+      -> const std::vector<InterfaceInfo>& {
+    static const std::vector<InterfaceInfo> kEmpty;
+    return kEmpty;
+  }
+
+  [[nodiscard]] virtual auto GetIncludeDirectories() const
+      -> const std::vector<CanonicalPath>& {
+    static const std::vector<CanonicalPath> kEmpty;
+    return kEmpty;
+  }
+
+  [[nodiscard]] virtual auto GetDefines() const
+      -> const std::vector<std::string>& {
+    static const std::vector<std::string> kEmpty;
+    return kEmpty;
+  }
+
+  // Version tracking for future atomic snapshots
+  [[nodiscard]] virtual auto GetVersion() const -> uint64_t {
+    return 0;
+  }
+};
+
+}  // namespace slangd

--- a/include/slangd/core/language_service_base.hpp
+++ b/include/slangd/core/language_service_base.hpp
@@ -35,6 +35,10 @@ class LanguageServiceBase {
   virtual auto GetDocumentSymbols(std::string uri)
       -> std::vector<lsp::DocumentSymbol> = 0;
 
+  // Workspace initialization - called during LSP initialize
+  virtual auto InitializeWorkspace(std::string workspace_uri)
+      -> asio::awaitable<void> = 0;
+
   // Config change handling - notifies service of configuration file changes
   virtual auto HandleConfigChange() -> void = 0;
 

--- a/include/slangd/core/language_service_base.hpp
+++ b/include/slangd/core/language_service_base.hpp
@@ -23,16 +23,18 @@ class LanguageServiceBase {
   virtual ~LanguageServiceBase() = default;
 
   // Diagnostics computation - async because may need parsing/compilation
-  virtual auto ComputeDiagnostics(std::string uri, std::string content)
+  virtual auto ComputeDiagnostics(
+      std::string uri, std::string content, int version)
       -> asio::awaitable<std::vector<lsp::Diagnostic>> = 0;
 
   // Definition lookup - sync because operates on existing compiled data
   virtual auto GetDefinitionsForPosition(
-      std::string uri, lsp::Position position)
+      std::string uri, lsp::Position position, std::string content, int version)
       -> std::vector<lsp::Location> = 0;
 
   // Document symbols - sync because operates on existing compiled data
-  virtual auto GetDocumentSymbols(std::string uri)
+  virtual auto GetDocumentSymbols(
+      std::string uri, std::string content, int version)
       -> std::vector<lsp::DocumentSymbol> = 0;
 
   // Workspace initialization - called during LSP initialize

--- a/include/slangd/semantic/definition_index.hpp
+++ b/include/slangd/semantic/definition_index.hpp
@@ -1,0 +1,103 @@
+#pragma once
+
+#include <optional>
+#include <unordered_map>
+#include <unordered_set>
+
+#include <spdlog/spdlog.h>
+
+#include "slang/ast/Compilation.h"
+#include "slang/text/SourceLocation.h"
+
+namespace slangd::semantic {
+
+// Uniquely identifies a symbol by its declaration location
+struct SymbolKey {
+  uint32_t bufferId;
+  size_t offset;
+
+  auto operator==(const SymbolKey&) const -> bool = default;
+
+  // Factory method to create from SourceLocation
+  static auto FromSourceLocation(const slang::SourceLocation& loc)
+      -> SymbolKey {
+    return SymbolKey{.bufferId = loc.buffer().getId(), .offset = loc.offset()};
+  }
+};
+
+}  // namespace slangd::semantic
+
+namespace std {
+template <>
+struct hash<slangd::semantic::SymbolKey> {
+  auto operator()(const slangd::semantic::SymbolKey& key) const -> size_t {
+    size_t hash = std::hash<uint32_t>()(key.bufferId);
+    hash ^= std::hash<size_t>()(key.offset) + 0x9e3779b9 + (hash << 6) +
+            (hash >> 2);
+    return hash;
+  }
+};
+}  // namespace std
+
+namespace slangd::semantic {
+
+class DefinitionIndex {
+ public:
+  DefinitionIndex() = delete;
+
+  // Create a definition index from a compilation
+  static auto FromCompilation(
+      slang::ast::Compilation& compilation,
+      const std::unordered_set<slang::BufferID>& traverse_buffers = {},
+      std::shared_ptr<spdlog::logger> logger = nullptr) -> DefinitionIndex;
+
+  // Looks up a symbol at the given location
+  auto LookupSymbolAt(slang::SourceLocation loc) const
+      -> std::optional<SymbolKey>;
+
+  // Gets the definition range for a symbol
+  auto GetDefinitionRange(const SymbolKey& key) const
+      -> std::optional<slang::SourceRange>;
+
+  [[nodiscard]] auto GetDefinitionRanges() const
+      -> const std::unordered_map<SymbolKey, slang::SourceRange>& {
+    return definition_locations_;
+  }
+
+  [[nodiscard]] auto GetReferenceMap() const
+      -> const std::unordered_map<slang::SourceRange, SymbolKey>& {
+    return reference_map_;
+  }
+
+  // Helper method for debugging
+  auto PrintInfo() const -> void;
+
+  // Adds a definition location for a symbol
+  // This will also add the symbol to the reference map
+  void AddDefinition(const SymbolKey& key, const slang::SourceRange& range);
+
+  // Adds a reference location for a symbol
+  void AddReference(const slang::SourceRange& range, const SymbolKey& key);
+
+ private:
+  explicit DefinitionIndex(
+      slang::ast::Compilation& compilation,
+      std::shared_ptr<spdlog::logger> logger = nullptr)
+      : logger_(logger ? logger : spdlog::default_logger()),
+        compilation_(compilation) {
+  }
+
+  // Logger
+  std::shared_ptr<spdlog::logger> logger_;
+
+  // Store the compilation reference
+  std::reference_wrapper<slang::ast::Compilation> compilation_;
+
+  // Maps a symbol key to its declaration range
+  std::unordered_map<SymbolKey, slang::SourceRange> definition_locations_;
+
+  // Maps a source range to a referenced symbol key
+  std::unordered_map<slang::SourceRange, SymbolKey> reference_map_;
+};
+
+}  // namespace slangd::semantic

--- a/include/slangd/semantic/diagnostic_index.hpp
+++ b/include/slangd/semantic/diagnostic_index.hpp
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <lsp/basic.hpp>
+#include <lsp/document_features.hpp>
+#include <slang/ast/Compilation.h>
+#include <slang/diagnostics/DiagnosticEngine.h>
+#include <slang/syntax/SyntaxTree.h>
+#include <slang/text/SourceManager.h>
+#include <spdlog/spdlog.h>
+
+namespace slangd::semantic {
+
+// Index of diagnostics extracted from a Slang compilation
+// Mirrors DefinitionIndex pattern for consistent architecture
+class DiagnosticIndex {
+ public:
+  DiagnosticIndex() = delete;
+
+  // Create a diagnostic index from a compilation
+  // Extracts and filters diagnostics for LSP consumption
+  static auto FromCompilation(
+      slang::ast::Compilation& compilation,
+      const slang::SourceManager& source_manager, const std::string& uri,
+      std::shared_ptr<spdlog::logger> logger = nullptr) -> DiagnosticIndex;
+
+  // Access the extracted diagnostics
+  [[nodiscard]] auto GetDiagnostics() const
+      -> const std::vector<lsp::Diagnostic>& {
+    return diagnostics_;
+  }
+
+  // Get the URI this index was created for
+  [[nodiscard]] auto GetUri() const -> const std::string& {
+    return uri_;
+  }
+
+  // Helper method for debugging
+  auto PrintInfo() const -> void;
+
+ private:
+  // Private constructor - use FromCompilation() factory method
+  DiagnosticIndex(
+      std::vector<lsp::Diagnostic> diagnostics, std::string uri,
+      std::shared_ptr<spdlog::logger> logger);
+
+  // Core extraction logic - semantic and syntax diagnostics
+  static auto ExtractDiagnosticsFromCompilation(
+      slang::ast::Compilation& compilation,
+      const slang::SourceManager& source_manager, const std::string& uri,
+      std::shared_ptr<spdlog::logger> logger) -> std::vector<lsp::Diagnostic>;
+
+  // Filter and modify diagnostics for LSP consumption
+  static auto FilterAndModifyDiagnostics(
+      std::vector<lsp::Diagnostic> diagnostics,
+      std::shared_ptr<spdlog::logger> logger) -> std::vector<lsp::Diagnostic>;
+
+  // Convert Slang diagnostics to LSP format
+  static auto ConvertSlangDiagnosticsToLsp(
+      const slang::Diagnostics& slang_diagnostics,
+      const slang::SourceManager& source_manager,
+      const slang::DiagnosticEngine& diag_engine, const std::string& uri)
+      -> std::vector<lsp::Diagnostic>;
+
+  // Helper conversion functions
+  static auto ConvertDiagnosticSeverityToLsp(slang::DiagnosticSeverity severity)
+      -> lsp::DiagnosticSeverity;
+
+  static auto IsDiagnosticInUriDocument(
+      const slang::Diagnostic& diag, const slang::SourceManager& source_manager,
+      const std::string& uri) -> bool;
+
+  // Core data
+  std::vector<lsp::Diagnostic> diagnostics_;
+  std::string uri_;
+  std::shared_ptr<spdlog::logger> logger_;
+};
+
+}  // namespace slangd::semantic

--- a/include/slangd/semantic/symbol_index.hpp
+++ b/include/slangd/semantic/symbol_index.hpp
@@ -1,103 +1,85 @@
 #pragma once
 
-#include <optional>
-#include <unordered_map>
+#include <functional>
+#include <memory>
+#include <string>
 #include <unordered_set>
+#include <vector>
 
+#include <lsp/document_features.hpp>
+#include <slang/ast/Compilation.h>
+#include <slang/text/SourceManager.h>
 #include <spdlog/spdlog.h>
-
-#include "slang/ast/Compilation.h"
-#include "slang/text/SourceLocation.h"
-
-namespace slangd::semantic {
-
-// Uniquely identifies a symbol by its declaration location
-struct SymbolKey {
-  uint32_t bufferId;
-  size_t offset;
-
-  auto operator==(const SymbolKey&) const -> bool = default;
-
-  // Factory method to create from SourceLocation
-  static auto FromSourceLocation(const slang::SourceLocation& loc)
-      -> SymbolKey {
-    return SymbolKey{.bufferId = loc.buffer().getId(), .offset = loc.offset()};
-  }
-};
-
-}  // namespace slangd::semantic
-
-namespace std {
-template <>
-struct hash<slangd::semantic::SymbolKey> {
-  auto operator()(const slangd::semantic::SymbolKey& key) const -> size_t {
-    size_t hash = std::hash<uint32_t>()(key.bufferId);
-    hash ^= std::hash<size_t>()(key.offset) + 0x9e3779b9 + (hash << 6) +
-            (hash >> 2);
-    return hash;
-  }
-};
-}  // namespace std
 
 namespace slangd::semantic {
 
 class SymbolIndex {
  public:
-  SymbolIndex() = delete;
-
-  // Create a symbol index from a compilation
+  // Factory method to create SymbolIndex from compilation
   static auto FromCompilation(
       slang::ast::Compilation& compilation,
-      const std::unordered_set<slang::BufferID>& traverse_buffers = {},
-      std::shared_ptr<spdlog::logger> logger = nullptr) -> SymbolIndex;
+      const slang::SourceManager& source_manager,
+      std::shared_ptr<spdlog::logger> logger = nullptr)
+      -> std::unique_ptr<SymbolIndex>;
 
-  // Looks up a symbol at the given location
-  auto LookupSymbolAt(slang::SourceLocation loc) const
-      -> std::optional<SymbolKey>;
-
-  // Gets the definition range for a symbol
-  auto GetDefinitionRange(const SymbolKey& key) const
-      -> std::optional<slang::SourceRange>;
-
-  [[nodiscard]] auto GetDefinitionRanges() const
-      -> const std::unordered_map<SymbolKey, slang::SourceRange>& {
-    return definition_locations_;
-  }
-
-  [[nodiscard]] auto GetReferenceMap() const
-      -> const std::unordered_map<slang::SourceRange, SymbolKey>& {
-    return reference_map_;
-  }
-
-  // Helper method for debugging
-  auto PrintInfo() const -> void;
-
-  // Adds a definition location for a symbol
-  // This will also add the symbol to the reference map
-  void AddDefinition(const SymbolKey& key, const slang::SourceRange& range);
-
-  // Adds a reference location for a symbol
-  void AddReference(const slang::SourceRange& range, const SymbolKey& key);
+  // Main LSP method: Get document symbols for given URI
+  [[nodiscard]] auto GetDocumentSymbols(const std::string& uri) const
+      -> std::vector<lsp::DocumentSymbol>;
 
  private:
   explicit SymbolIndex(
       slang::ast::Compilation& compilation,
-      std::shared_ptr<spdlog::logger> logger = nullptr)
-      : logger_(logger ? logger : spdlog::default_logger()),
-        compilation_(compilation) {
-  }
+      const slang::SourceManager& source_manager,
+      std::shared_ptr<spdlog::logger> logger);
 
-  // Logger
+  // Core data members
+  std::reference_wrapper<slang::ast::Compilation> compilation_;
+  std::reference_wrapper<const slang::SourceManager> source_manager_;
   std::shared_ptr<spdlog::logger> logger_;
 
-  // Store the compilation reference
-  std::reference_wrapper<slang::ast::Compilation> compilation_;
+  // Core resolver
+  [[nodiscard]] auto ResolveSymbolsFromCompilation(const std::string& uri) const
+      -> std::vector<lsp::DocumentSymbol>;
 
-  // Maps a symbol key to its declaration range
-  std::unordered_map<SymbolKey, slang::SourceRange> definition_locations_;
+  // Symbol hierarchy builder
+  void BuildSymbolHierarchy(
+      const slang::ast::Symbol& symbol,
+      std::vector<lsp::DocumentSymbol>& document_symbols,
+      const std::string& uri,
+      std::unordered_set<std::string>& seen_names) const;
 
-  // Maps a source range to a referenced symbol key
-  std::unordered_map<slang::SourceRange, SymbolKey> reference_map_;
+  void BuildSymbolChildren(
+      const slang::ast::Symbol& symbol, lsp::DocumentSymbol& parent_symbol,
+      const std::string& uri) const;
+
+  void BuildScopeSymbolChildren(
+      const slang::ast::Scope& scope, lsp::DocumentSymbol& parent_symbol,
+      const std::string& uri) const;
+
+  // Conversion utilities
+  static auto ConvertSymbolKindToLsp(const slang::ast::Symbol& symbol)
+      -> lsp::SymbolKind;
+
+  static auto ConvertSymbolNameRangeToLsp(
+      const slang::ast::Symbol& symbol,
+      const slang::SourceManager& source_manager) -> lsp::Range;
+
+  // Filter and unwrap
+  static auto IsSymbolInDocument(
+      const slang::ast::Symbol& symbol,
+      const slang::SourceManager& source_manager, const std::string& uri)
+      -> bool;
+
+  static auto IsRelevantDocumentSymbol(const slang::ast::Symbol& symbol)
+      -> bool;
+
+  static auto IsSymbolInUriDocument(
+      const slang::ast::Symbol& symbol,
+      const slang::SourceManager& source_manager, const std::string& uri)
+      -> bool;
+
+  static auto GetUnwrappedSymbol(const slang::ast::Symbol& symbol)
+      -> const slang::ast::Symbol&;
 };
 
 }  // namespace slangd::semantic

--- a/include/slangd/services/legacy/definition_provider.hpp
+++ b/include/slangd/services/legacy/definition_provider.hpp
@@ -31,8 +31,8 @@ class DefinitionProvider : public LanguageFeatureProvider {
       -> std::vector<lsp::Location>;
 
   // Core resolvers
-  static auto ResolveDefinitionFromSymbolIndex(
-      const semantic::SymbolIndex& index,
+  static auto ResolveDefinitionFromDefinitionIndex(
+      const semantic::DefinitionIndex& index,
       const std::shared_ptr<slang::SourceManager>& source_manager,
       slang::SourceLocation location) -> std::vector<lsp::Location>;
 };

--- a/include/slangd/services/legacy/document_manager.hpp
+++ b/include/slangd/services/legacy/document_manager.hpp
@@ -12,7 +12,7 @@
 
 #include "slangd/core/project_layout.hpp"
 #include "slangd/core/project_layout_service.hpp"
-#include "slangd/semantic/symbol_index.hpp"
+#include "slangd/semantic/definition_index.hpp"
 
 namespace slangd {
 
@@ -44,8 +44,8 @@ class DocumentManager {
       -> std::shared_ptr<slang::SourceManager>;
 
   // Get the symbol index for a document
-  auto GetSymbolIndex(std::string uri)
-      -> std::shared_ptr<semantic::SymbolIndex>;
+  auto GetDefinitionIndex(std::string uri)
+      -> std::shared_ptr<semantic::DefinitionIndex>;
 
   // Check layout version and rebuild document settings if changed
   auto MaybeRebuildIfLayoutChanged() -> asio::awaitable<void>;
@@ -73,7 +73,7 @@ class DocumentManager {
       source_managers_;
 
   // Maps document URIs to their symbol indices
-  std::unordered_map<CanonicalPath, std::shared_ptr<semantic::SymbolIndex>>
+  std::unordered_map<CanonicalPath, std::shared_ptr<semantic::DefinitionIndex>>
       symbol_indices_;
 
   // Version tracking for efficient layout changes

--- a/include/slangd/services/legacy/legacy_language_service.hpp
+++ b/include/slangd/services/legacy/legacy_language_service.hpp
@@ -23,16 +23,18 @@ class LegacyLanguageService : public LanguageServiceBase {
       std::shared_ptr<spdlog::logger> logger = nullptr);
 
   // Initialize with workspace folder (called during LSP initialize)
-  auto InitializeWorkspace(std::string workspace_uri) -> asio::awaitable<void>;
+  auto InitializeWorkspace(std::string workspace_uri)
+      -> asio::awaitable<void> override;
 
   // LanguageServiceBase implementation
-  auto ComputeDiagnostics(std::string uri, std::string content)
+  auto ComputeDiagnostics(std::string uri, std::string content, int version)
       -> asio::awaitable<std::vector<lsp::Diagnostic>> override;
 
-  auto GetDefinitionsForPosition(std::string uri, lsp::Position position)
+  auto GetDefinitionsForPosition(
+      std::string uri, lsp::Position position, std::string content, int version)
       -> std::vector<lsp::Location> override;
 
-  auto GetDocumentSymbols(std::string uri)
+  auto GetDocumentSymbols(std::string uri, std::string content, int version)
       -> std::vector<lsp::DocumentSymbol> override;
 
   auto HandleConfigChange() -> void override;

--- a/include/slangd/services/legacy/symbols_provider.hpp
+++ b/include/slangd/services/legacy/symbols_provider.hpp
@@ -63,15 +63,14 @@ class SymbolsProvider : public LanguageFeatureProvider {
 
   static auto ConvertSymbolNameRangeToLsp(
       const slang::ast::Symbol& symbol,
-      const std::shared_ptr<slang::SourceManager>& source_manager)
-      -> lsp::Range;
+      const slang::SourceManager& source_manager) -> lsp::Range;
 
   // Filter and unwrap
   // Check if a symbol is physically located in the document
   static auto IsSymbolInDocument(
       const slang::ast::Symbol& symbol,
-      const std::shared_ptr<slang::SourceManager>& source_manager,
-      const std::string& uri) -> bool;
+      const slang::SourceManager& source_manager, const std::string& uri)
+      -> bool;
 
   // Check if a symbol should be included in document symbols (outline view)
   static auto IsRelevantDocumentSymbol(const slang::ast::Symbol& symbol)
@@ -81,8 +80,8 @@ class SymbolsProvider : public LanguageFeatureProvider {
   // compatibility
   static auto IsSymbolInUriDocument(
       const slang::ast::Symbol& symbol,
-      const std::shared_ptr<slang::SourceManager>& source_manager,
-      const std::string& uri) -> bool;
+      const slang::SourceManager& source_manager, const std::string& uri)
+      -> bool;
 
   static auto GetUnwrappedSymbol(const slang::ast::Symbol& symbol)
       -> const slang::ast::Symbol&;

--- a/include/slangd/services/legacy/workspace_manager.hpp
+++ b/include/slangd/services/legacy/workspace_manager.hpp
@@ -15,7 +15,7 @@
 #include "lsp/workspace.hpp"
 #include "slangd/core/project_layout.hpp"
 #include "slangd/core/project_layout_service.hpp"
-#include "slangd/semantic/symbol_index.hpp"
+#include "slangd/semantic/definition_index.hpp"
 #include "slangd/utils/canonical_path.hpp"
 
 namespace slangd {
@@ -43,7 +43,7 @@ class WorkspaceManager {
       -> asio::awaitable<void>;
 
   // Rebuild the symbol index
-  void RebuildSymbolIndex();
+  void RebuildDefinitionIndex();
 
   // Get the compilation for this workspace
   [[nodiscard]] auto GetCompilation() const
@@ -74,7 +74,8 @@ class WorkspaceManager {
   }
 
   // Get the workspace symbol index
-  auto GetSymbolIndex() const -> std::shared_ptr<semantic::SymbolIndex> {
+  auto GetDefinitionIndex() const
+      -> std::shared_ptr<semantic::DefinitionIndex> {
     return symbol_index_;
   }
 
@@ -137,7 +138,7 @@ class WorkspaceManager {
   std::shared_ptr<ProjectLayoutService> layout_service_;
 
   // Workspace symbol index
-  std::shared_ptr<semantic::SymbolIndex> symbol_index_{nullptr};
+  std::shared_ptr<semantic::DefinitionIndex> symbol_index_{nullptr};
 
   // Track open buffers
   std::unordered_set<slang::BufferID> open_buffers_;

--- a/include/slangd/services/new/new_language_service.hpp
+++ b/include/slangd/services/new/new_language_service.hpp
@@ -13,7 +13,7 @@
 namespace slangd::services::new_service {
 
 // New service implementation using overlay sessions
-// Creates fresh Compilation + SymbolIndex per LSP request
+// Creates fresh Compilation + DefinitionIndex per LSP request
 // Designed for GlobalCatalog integration (Phase 2)
 class NewLanguageService : public LanguageServiceBase {
  public:
@@ -24,7 +24,8 @@ class NewLanguageService : public LanguageServiceBase {
 
   // Initialize with workspace folder (called during LSP initialize)
   // Same pattern as LegacyLanguageService for compatibility
-  auto InitializeWorkspace(std::string workspace_uri) -> asio::awaitable<void>;
+  auto InitializeWorkspace(std::string workspace_uri)
+      -> asio::awaitable<void> override;
 
   // LanguageServiceBase implementation using overlay sessions
   auto ComputeDiagnostics(std::string uri, std::string content)
@@ -44,24 +45,6 @@ class NewLanguageService : public LanguageServiceBase {
   // Create overlay session for the given URI and content
   auto CreateOverlaySession(std::string uri, std::string content)
       -> std::unique_ptr<overlay::OverlaySession>;
-
-  // Convert Slang diagnostics to LSP diagnostics
-  auto ConvertSlangDiagnosticsToLsp(
-      const slang::ast::Compilation& compilation,
-      const slang::SourceManager& source_manager, const std::string& uri)
-      -> std::vector<lsp::Diagnostic>;
-
-  // Convert SymbolIndex results to LSP locations
-  auto ConvertSymbolIndexToLspLocations(
-      const semantic::SymbolIndex& symbol_index,
-      const slang::SourceManager& source_manager,
-      const semantic::SymbolKey& symbol_key) -> std::vector<lsp::Location>;
-
-  // Extract document symbols from SymbolIndex
-  auto ExtractDocumentSymbolsFromIndex(
-      const semantic::SymbolIndex& symbol_index,
-      const slang::SourceManager& source_manager, const std::string& uri)
-      -> std::vector<lsp::DocumentSymbol>;
 
   // Core dependencies
   std::shared_ptr<ProjectLayoutService> layout_service_;

--- a/include/slangd/services/new/new_language_service.hpp
+++ b/include/slangd/services/new/new_language_service.hpp
@@ -1,6 +1,10 @@
 #pragma once
 
+#include <chrono>
+#include <functional>
 #include <memory>
+#include <string>
+#include <vector>
 
 #include <asio.hpp>
 #include <spdlog/spdlog.h>
@@ -11,6 +15,30 @@
 #include "slangd/services/new/overlay_session.hpp"
 
 namespace slangd::services::new_service {
+
+// Cache key for overlay sessions
+struct OverlayCacheKey {
+  std::string doc_uri;
+  int doc_version;
+  uint64_t catalog_version;
+
+  auto operator==(const OverlayCacheKey& other) const -> bool {
+    return doc_uri == other.doc_uri && doc_version == other.doc_version &&
+           catalog_version == other.catalog_version;
+  }
+
+  [[nodiscard]] auto Hash() const -> size_t {
+    size_t h1 = std::hash<std::string>{}(doc_uri);
+    size_t h2 = std::hash<int>{}(doc_version);
+    size_t h3 = std::hash<uint64_t>{}(catalog_version);
+
+    // Combine hashes using boost-style hash combination
+    size_t result = h1;
+    result ^= h2 + 0x9e3779b9 + (result << 6) + (result >> 2);
+    result ^= h3 + 0x9e3779b9 + (result << 6) + (result >> 2);
+    return result;
+  }
+};
 
 // New service implementation using overlay sessions
 // Creates fresh Compilation + DefinitionIndex per LSP request
@@ -28,13 +56,14 @@ class NewLanguageService : public LanguageServiceBase {
       -> asio::awaitable<void> override;
 
   // LanguageServiceBase implementation using overlay sessions
-  auto ComputeDiagnostics(std::string uri, std::string content)
+  auto ComputeDiagnostics(std::string uri, std::string content, int version)
       -> asio::awaitable<std::vector<lsp::Diagnostic>> override;
 
-  auto GetDefinitionsForPosition(std::string uri, lsp::Position position)
+  auto GetDefinitionsForPosition(
+      std::string uri, lsp::Position position, std::string content, int version)
       -> std::vector<lsp::Location> override;
 
-  auto GetDocumentSymbols(std::string uri)
+  auto GetDocumentSymbols(std::string uri, std::string content, int version)
       -> std::vector<lsp::DocumentSymbol> override;
 
   auto HandleConfigChange() -> void override;
@@ -42,15 +71,34 @@ class NewLanguageService : public LanguageServiceBase {
   auto HandleSourceFileChange() -> void override;
 
  private:
+  // Cache entry for overlay sessions
+  struct CacheEntry {
+    OverlayCacheKey key;
+    std::shared_ptr<overlay::OverlaySession> session;
+    std::chrono::steady_clock::time_point last_access;
+  };
+
   // Create overlay session for the given URI and content
   auto CreateOverlaySession(std::string uri, std::string content)
-      -> std::unique_ptr<overlay::OverlaySession>;
+      -> std::shared_ptr<overlay::OverlaySession>;
+
+  // Get or create overlay session from cache
+  auto GetOrCreateOverlay(
+      const OverlayCacheKey& key, const std::string& content)
+      -> std::shared_ptr<overlay::OverlaySession>;
+
+  // Clear cache when catalog version changes
+  auto ClearCache() -> void;
 
   // Core dependencies
   std::shared_ptr<ProjectLayoutService> layout_service_;
   std::shared_ptr<const GlobalCatalog> global_catalog_;  // nullptr for Phase 1a
   std::shared_ptr<spdlog::logger> logger_;
   asio::any_io_executor executor_;
+
+  // LRU cache for overlay sessions
+  std::vector<CacheEntry> overlay_cache_;
+  static constexpr size_t kMaxCacheSize = 8;
 };
 
 }  // namespace slangd::services::new_service

--- a/include/slangd/services/new/new_language_service.hpp
+++ b/include/slangd/services/new/new_language_service.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <memory>
+
+#include <asio.hpp>
+#include <spdlog/spdlog.h>
+
+#include "slangd/core/global_catalog.hpp"
+#include "slangd/core/language_service_base.hpp"
+#include "slangd/core/project_layout_service.hpp"
+#include "slangd/services/new/overlay_session.hpp"
+
+namespace slangd::services::new_service {
+
+// New service implementation using overlay sessions
+// Creates fresh Compilation + SymbolIndex per LSP request
+// Designed for GlobalCatalog integration (Phase 2)
+class NewLanguageService : public LanguageServiceBase {
+ public:
+  // Constructor for late initialization (workspace set up later)
+  explicit NewLanguageService(
+      asio::any_io_executor executor,
+      std::shared_ptr<spdlog::logger> logger = nullptr);
+
+  // Initialize with workspace folder (called during LSP initialize)
+  // Same pattern as LegacyLanguageService for compatibility
+  auto InitializeWorkspace(std::string workspace_uri) -> asio::awaitable<void>;
+
+  // LanguageServiceBase implementation using overlay sessions
+  auto ComputeDiagnostics(std::string uri, std::string content)
+      -> asio::awaitable<std::vector<lsp::Diagnostic>> override;
+
+  auto GetDefinitionsForPosition(std::string uri, lsp::Position position)
+      -> std::vector<lsp::Location> override;
+
+  auto GetDocumentSymbols(std::string uri)
+      -> std::vector<lsp::DocumentSymbol> override;
+
+  auto HandleConfigChange() -> void override;
+
+  auto HandleSourceFileChange() -> void override;
+
+ private:
+  // Create overlay session for the given URI and content
+  auto CreateOverlaySession(std::string uri, std::string content)
+      -> std::unique_ptr<overlay::OverlaySession>;
+
+  // Convert Slang diagnostics to LSP diagnostics
+  auto ConvertSlangDiagnosticsToLsp(
+      const slang::ast::Compilation& compilation,
+      const slang::SourceManager& source_manager, const std::string& uri)
+      -> std::vector<lsp::Diagnostic>;
+
+  // Convert SymbolIndex results to LSP locations
+  auto ConvertSymbolIndexToLspLocations(
+      const semantic::SymbolIndex& symbol_index,
+      const slang::SourceManager& source_manager,
+      const semantic::SymbolKey& symbol_key) -> std::vector<lsp::Location>;
+
+  // Extract document symbols from SymbolIndex
+  auto ExtractDocumentSymbolsFromIndex(
+      const semantic::SymbolIndex& symbol_index,
+      const slang::SourceManager& source_manager, const std::string& uri)
+      -> std::vector<lsp::DocumentSymbol>;
+
+  // Core dependencies
+  std::shared_ptr<ProjectLayoutService> layout_service_;
+  std::shared_ptr<const GlobalCatalog> global_catalog_;  // nullptr for Phase 1a
+  std::shared_ptr<spdlog::logger> logger_;
+  asio::any_io_executor executor_;
+};
+
+}  // namespace slangd::services::new_service

--- a/include/slangd/services/new/overlay_session.hpp
+++ b/include/slangd/services/new/overlay_session.hpp
@@ -9,6 +9,8 @@
 
 #include "slangd/core/global_catalog.hpp"
 #include "slangd/core/project_layout_service.hpp"
+#include "slangd/semantic/definition_index.hpp"
+#include "slangd/semantic/diagnostic_index.hpp"
 #include "slangd/semantic/symbol_index.hpp"
 
 namespace slangd::services::overlay {
@@ -35,11 +37,23 @@ class OverlaySession {
   ~OverlaySession() = default;
 
   // Access to symbol index for LSP queries
+  [[nodiscard]] auto GetDefinitionIndex() const
+      -> const semantic::DefinitionIndex& {
+    return *definition_index_;
+  }
+
+  // Access to diagnostic index for LSP diagnostics
+  [[nodiscard]] auto GetDiagnosticIndex() const
+      -> const semantic::DiagnosticIndex& {
+    return *diagnostic_index_;
+  }
+
+  // Access to symbol index for document symbols
   [[nodiscard]] auto GetSymbolIndex() const -> const semantic::SymbolIndex& {
     return *symbol_index_;
   }
 
-  // Access to compilation for diagnostics
+  // Access to compilation for advanced queries
   [[nodiscard]] auto GetCompilation() const -> slang::ast::Compilation& {
     return *compilation_;
   }
@@ -54,6 +68,8 @@ class OverlaySession {
   OverlaySession(
       std::shared_ptr<slang::SourceManager> source_manager,
       std::unique_ptr<slang::ast::Compilation> compilation,
+      std::unique_ptr<semantic::DefinitionIndex> definition_index,
+      std::unique_ptr<semantic::DiagnosticIndex> diagnostic_index,
       std::unique_ptr<semantic::SymbolIndex> symbol_index,
       std::shared_ptr<spdlog::logger> logger);
 
@@ -70,6 +86,8 @@ class OverlaySession {
   // Core session components
   std::shared_ptr<slang::SourceManager> source_manager_;
   std::unique_ptr<slang::ast::Compilation> compilation_;
+  std::unique_ptr<semantic::DefinitionIndex> definition_index_;
+  std::unique_ptr<semantic::DiagnosticIndex> diagnostic_index_;
   std::unique_ptr<semantic::SymbolIndex> symbol_index_;
   std::shared_ptr<spdlog::logger> logger_;
 };

--- a/include/slangd/services/new/overlay_session.hpp
+++ b/include/slangd/services/new/overlay_session.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include <slang/ast/Compilation.h>
+#include <slang/text/SourceManager.h>
+#include <spdlog/spdlog.h>
+
+#include "slangd/core/global_catalog.hpp"
+#include "slangd/core/project_layout_service.hpp"
+#include "slangd/semantic/symbol_index.hpp"
+
+namespace slangd::services::overlay {
+
+// Per-request compilation session for LSP queries
+// Creates fresh Slang compilation with current buffer + optional catalog files
+// Provides symbol indexing for go-to-definition and document symbols
+class OverlaySession {
+ public:
+  // Factory method for creating overlay sessions
+  // catalog can be nullptr - session will work in single-file mode
+  static auto Create(
+      std::string uri, std::string content,
+      std::shared_ptr<ProjectLayoutService> layout_service,
+      std::shared_ptr<const GlobalCatalog> catalog = nullptr,
+      std::shared_ptr<spdlog::logger> logger = nullptr)
+      -> std::unique_ptr<OverlaySession>;
+
+  // Move-only type for performance
+  OverlaySession(const OverlaySession&) = delete;
+  OverlaySession(OverlaySession&&) = default;
+  auto operator=(const OverlaySession&) -> OverlaySession& = delete;
+  auto operator=(OverlaySession&&) -> OverlaySession& = default;
+  ~OverlaySession() = default;
+
+  // Access to symbol index for LSP queries
+  [[nodiscard]] auto GetSymbolIndex() const -> const semantic::SymbolIndex& {
+    return *symbol_index_;
+  }
+
+  // Access to compilation for diagnostics
+  [[nodiscard]] auto GetCompilation() const -> slang::ast::Compilation& {
+    return *compilation_;
+  }
+
+  // Access to source manager for location mapping
+  [[nodiscard]] auto GetSourceManager() const -> const slang::SourceManager& {
+    return *source_manager_;
+  }
+
+ private:
+  // Private constructor - use Create() factory method
+  OverlaySession(
+      std::shared_ptr<slang::SourceManager> source_manager,
+      std::unique_ptr<slang::ast::Compilation> compilation,
+      std::unique_ptr<semantic::SymbolIndex> symbol_index,
+      std::shared_ptr<spdlog::logger> logger);
+
+  // Build fresh compilation with current buffer and optional catalog files
+  static auto BuildCompilation(
+      std::string uri, std::string content,
+      std::shared_ptr<ProjectLayoutService> layout_service,
+      std::shared_ptr<const GlobalCatalog> catalog,
+      std::shared_ptr<spdlog::logger> logger)
+      -> std::tuple<
+          std::shared_ptr<slang::SourceManager>,
+          std::unique_ptr<slang::ast::Compilation>>;
+
+  // Core session components
+  std::shared_ptr<slang::SourceManager> source_manager_;
+  std::unique_ptr<slang::ast::Compilation> compilation_;
+  std::unique_ptr<semantic::SymbolIndex> symbol_index_;
+  std::shared_ptr<spdlog::logger> logger_;
+};
+
+}  // namespace slangd::services::overlay

--- a/include/slangd/services/new/overlay_session.hpp
+++ b/include/slangd/services/new/overlay_session.hpp
@@ -27,7 +27,7 @@ class OverlaySession {
       std::shared_ptr<ProjectLayoutService> layout_service,
       std::shared_ptr<const GlobalCatalog> catalog = nullptr,
       std::shared_ptr<spdlog::logger> logger = nullptr)
-      -> std::unique_ptr<OverlaySession>;
+      -> std::shared_ptr<OverlaySession>;
 
   // Move-only type for performance
   OverlaySession(const OverlaySession&) = delete;

--- a/include/slangd/utils/conversion.hpp
+++ b/include/slangd/utils/conversion.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <memory>
-
 #include <slang/text/SourceLocation.h>
 #include <slang/text/SourceManager.h>
 
@@ -12,31 +10,28 @@ namespace slangd {
 // Convert a Slang source location to a zero-length LSP range at that point
 auto ConvertSlangLocationToLspRange(
     const slang::SourceLocation& location,
-    const std::shared_ptr<slang::SourceManager>& source_manager) -> lsp::Range;
+    const slang::SourceManager& source_manager) -> lsp::Range;
 
 // Convert a Slang source range to an LSP range
 auto ConvertSlangRangeToLspRange(
-    const slang::SourceRange& range,
-    const std::shared_ptr<slang::SourceManager>& source_manager) -> lsp::Range;
+    const slang::SourceRange& range, const slang::SourceManager& source_manager)
+    -> lsp::Range;
 
 // Convert an LSP position to a Slang source location
 auto ConvertLspPositionToSlangLocation(
     const lsp::Position& position, const slang::BufferID& buffer_id,
-    const std::shared_ptr<slang::SourceManager>& source_manager)
-    -> slang::SourceLocation;
+    const slang::SourceManager& source_manager) -> slang::SourceLocation;
 
 // Convert a Slang source location to an LSP location (with URI and a
 // zero-length range)
 auto ConvertSlangLocationToLspLocation(
     const slang::SourceLocation& location,
-    const std::shared_ptr<slang::SourceManager>& source_manager)
-    -> lsp::Location;
+    const slang::SourceManager& source_manager) -> lsp::Location;
 
 // Convert a Slang source location to an LSP position
 auto ConvertSlangLocationToLspPosition(
     const slang::SourceLocation& location,
-    const std::shared_ptr<slang::SourceManager>& source_manager)
-    -> lsp::Position;
+    const slang::SourceManager& source_manager) -> lsp::Position;
 
 // convert const std::optional<nlohmann::json>& json to LSP strong type
 template <typename T>

--- a/include/slangd/utils/path_utils.hpp
+++ b/include/slangd/utils/path_utils.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <string>
 #include <string_view>
 
@@ -23,7 +22,6 @@ namespace slangd {
 // TODO(hankhsu1996) find a better place for this
 [[nodiscard]] auto IsLocationInDocument(
     const slang::SourceLocation& location,
-    const std::shared_ptr<slang::SourceManager>& source_manager,
-    std::string_view uri) -> bool;
+    const slang::SourceManager& source_manager, std::string_view uri) -> bool;
 
 }  // namespace slangd

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,12 +10,12 @@
 #include "app/app_setup.hpp"
 #include "app/crash_handler.hpp"
 #include "slangd/core/slangd_lsp_server.hpp"
-#include "slangd/services/legacy/legacy_language_service.hpp"
+#include "slangd/services/new/new_language_service.hpp"
 
 using jsonrpc::endpoint::RpcEndpoint;
 using jsonrpc::transport::FramedPipeTransport;
-using slangd::LegacyLanguageService;
 using slangd::SlangdLspServer;
+using slangd::services::new_service::NewLanguageService;
 
 auto main(int argc, char* argv[]) -> int {
   // Initialize debugging features
@@ -47,7 +47,7 @@ auto main(int argc, char* argv[]) -> int {
 
   // Create the language service and LSP server with dependency injection
   auto language_service =
-      std::make_shared<LegacyLanguageService>(executor, loggers["slangd"]);
+      std::make_shared<NewLanguageService>(executor, loggers["slangd"]);
   auto server = std::make_unique<SlangdLspServer>(
       executor, std::move(endpoint), language_service, loggers["slangd"]);
 

--- a/src/slangd/core/slangd_lsp_server.cpp
+++ b/src/slangd/core/slangd_lsp_server.cpp
@@ -6,7 +6,7 @@
 #include <spdlog/spdlog.h>
 
 #include "lsp/document_features.hpp"
-#include "slangd/services/legacy/legacy_language_service.hpp"
+#include "slangd/utils/canonical_path.hpp"
 #include "slangd/utils/path_utils.hpp"
 
 namespace slangd {
@@ -41,13 +41,8 @@ auto SlangdLspServer::OnInitialize(lsp::InitializeParams params)
 
     const auto& workspace_folder = workspace_folders_opt->front();
 
-    // Initialize language service with workspace - need to cast to
-    // LegacyLanguageService to access InitializeWorkspace
-    if (auto legacy_service =
-            std::dynamic_pointer_cast<slangd::LegacyLanguageService>(
-                language_service_)) {
-      co_await legacy_service->InitializeWorkspace(workspace_folder.uri);
-    }
+    // Initialize language service with workspace via facade interface
+    co_await language_service_->InitializeWorkspace(workspace_folder.uri);
   }
 
   lsp::TextDocumentSyncOptions sync_options{

--- a/src/slangd/semantic/definition_index.cpp
+++ b/src/slangd/semantic/definition_index.cpp
@@ -1,0 +1,408 @@
+#include "slangd/semantic/definition_index.hpp"
+
+#include <spdlog/spdlog.h>
+
+#include "slang/ast/ASTVisitor.h"
+#include "slang/ast/expressions/MiscExpressions.h"
+#include "slang/ast/symbols/CompilationUnitSymbols.h"
+#include "slang/ast/symbols/InstanceSymbols.h"
+#include "slang/syntax/AllSyntax.h"
+
+namespace slangd::semantic {
+
+void DefinitionIndex::AddDefinition(
+    const SymbolKey& key, const slang::SourceRange& range) {
+  // Store the definition location
+  definition_locations_[key] = range;
+
+  // Also add the reference to the reference map
+  reference_map_[range] = key;
+}
+
+void DefinitionIndex::AddReference(
+    const slang::SourceRange& range, const SymbolKey& key) {
+  reference_map_[range] = key;
+}
+
+namespace {
+// Indexing helper functions
+
+[[maybe_unused]] void IndexPackage(
+    const slang::ast::PackageSymbol& symbol, DefinitionIndex& index) {
+  SymbolKey key = SymbolKey::FromSourceLocation(symbol.location);
+
+  if (const auto* syntax_node = symbol.getSyntax()) {
+    if (syntax_node->kind == slang::syntax::SyntaxKind::PackageDeclaration) {
+      // Module and package both use ModuleDeclarationSyntax
+      const auto& package_syntax =
+          syntax_node->as<slang::syntax::ModuleDeclarationSyntax>();
+
+      const auto& range = package_syntax.header->name.range();
+      index.AddDefinition(key, range);
+
+      // Handle endpackage name if present
+      if (const auto& end_name = package_syntax.blockName) {
+        index.AddReference(end_name->name.range(), key);
+      }
+    }
+  }
+}
+
+[[maybe_unused]] void IndexDefinition(
+    const slang::ast::DefinitionSymbol& def, DefinitionIndex& index,
+    slang::ast::Compilation& compilation) {
+  const auto* syntax = def.getSyntax();
+  if ((syntax != nullptr) &&
+      syntax->kind == slang::syntax::SyntaxKind::ModuleDeclaration) {
+    // Add the definition to the index
+    const auto& module_syntax =
+        syntax->as<slang::syntax::ModuleDeclarationSyntax>();
+    const auto& module_range = module_syntax.header->name.range();
+    SymbolKey key = SymbolKey::FromSourceLocation(def.location);
+    index.AddDefinition(key, module_range);
+
+    // Add the endmodule label to the reference map
+    if (const auto& end_label = module_syntax.blockName) {
+      index.AddReference(end_label->name.range(), key);
+    }
+
+    // Handle imports
+    for (const auto& import_decl : module_syntax.header->imports) {
+      for (const auto& import_item : import_decl->items) {
+        if (import_item->kind == slang::syntax::SyntaxKind::PackageImportItem) {
+          const auto& import_syntax =
+              import_item->as<slang::syntax::PackageImportItemSyntax>();
+          auto package_range = import_syntax.package.range();
+          const auto& package_name = import_syntax.package.valueText();
+          const auto* package_symbol = compilation.getPackage(package_name);
+          if (package_symbol != nullptr) {
+            SymbolKey key =
+                SymbolKey::FromSourceLocation(package_symbol->location);
+            index.AddReference(package_range, key);
+          }
+        }
+      }
+    }
+  }
+}
+
+[[maybe_unused]] void IndexUninstantiatedDef(
+    const slang::ast::UninstantiatedDefSymbol& symbol, DefinitionIndex& index,
+    slang::ast::Compilation& compilation) {
+  // Get the instance type location
+  slang::SourceRange instance_type_range;
+  if (symbol.getSyntax()->kind ==
+      slang::syntax::SyntaxKind::HierarchicalInstance) {
+    const auto& hierarchical_instance_syntax =
+        symbol.getSyntax()->as<slang::syntax::HierarchicalInstanceSyntax>();
+    // Try get parent and convert to HierarchicalInstantiationSyntax to get the
+    // type range
+    if (const auto* parent = hierarchical_instance_syntax.parent) {
+      if (parent->kind == slang::syntax::SyntaxKind::HierarchyInstantiation) {
+        instance_type_range =
+            parent->as<slang::syntax::HierarchyInstantiationSyntax>()
+                .type.range();
+      }
+    }
+  }
+
+  // Lookup for the module definition. If found, add the instance type to
+  // the reference map
+  const auto* scope = symbol.getParentScope();
+  if (scope != nullptr) {
+    auto module_def =
+        compilation.tryGetDefinition(symbol.definitionName, *scope);
+    if (module_def.definition != nullptr) {
+      const auto* syntax = module_def.definition->getSyntax();
+      if (syntax->kind == slang::syntax::SyntaxKind::ModuleDeclaration) {
+        const auto& module_syntax =
+            syntax->as<slang::syntax::ModuleDeclarationSyntax>();
+        auto module_def_location = module_syntax.header->name.range().start();
+        SymbolKey key = SymbolKey::FromSourceLocation(module_def_location);
+
+        index.AddReference(instance_type_range, key);
+      }
+    }
+  }
+
+  // Add the instance name to the definition map
+  if (const auto& symbol_syntax = symbol.getSyntax()) {
+    if (symbol_syntax->kind ==
+        slang::syntax::SyntaxKind::HierarchicalInstance) {
+      const auto& instance_syntax =
+          symbol_syntax->as<slang::syntax::HierarchicalInstanceSyntax>();
+
+      // Instance name definition
+      if (instance_syntax.decl != nullptr) {
+        SymbolKey key = SymbolKey::FromSourceLocation(symbol.location);
+        index.AddDefinition(key, instance_syntax.decl->name.range());
+      }
+    }
+  }
+}
+
+[[maybe_unused]] void IndexTypeAlias(
+    const slang::ast::TypeAliasType& symbol, DefinitionIndex& index) {
+  const auto& loc = symbol.location;
+  SymbolKey key = SymbolKey::FromSourceLocation(loc);
+
+  if (const auto& symbol_syntax = symbol.getSyntax()) {
+    if (symbol_syntax->kind == slang::syntax::SyntaxKind::TypedefDeclaration) {
+      const auto& type_alias_syntax =
+          symbol_syntax->as<slang::syntax::TypedefDeclarationSyntax>();
+      index.AddDefinition(key, type_alias_syntax.name.range());
+    }
+  }
+
+  // If it's an enum type, process all enum values
+  if (symbol.targetType.getType().kind == slang::ast::SymbolKind::EnumType) {
+    const auto& enum_type =
+        symbol.targetType.getType().as<slang::ast::EnumType>();
+    for (const auto& enum_value : enum_type.values()) {
+      auto key = SymbolKey::FromSourceLocation(enum_value.location);
+      if (const auto& value_syntax = enum_value.getSyntax()) {
+        index.AddDefinition(key, value_syntax->sourceRange());
+      }
+    }
+  }
+}
+
+[[maybe_unused]] void IndexVariable(
+    const slang::ast::VariableSymbol& symbol, DefinitionIndex& index) {
+  const auto& loc = symbol.location;
+  SymbolKey key = SymbolKey::FromSourceLocation(loc);
+
+  if (const auto& symbol_syntax = symbol.getSyntax()) {
+    index.AddDefinition(key, symbol_syntax->sourceRange());
+  }
+
+  // Variable type reference
+  const auto& declared_type = symbol.getDeclaredType();
+  if (const auto& type_syntax = declared_type->getTypeSyntax()) {
+    if (type_syntax->kind == slang::syntax::SyntaxKind::NamedType) {
+      const auto& named_type =
+          type_syntax->as<slang::syntax::NamedTypeSyntax>();
+      const auto& resolved_type = symbol.getType();
+      SymbolKey type_key =
+          SymbolKey::FromSourceLocation(resolved_type.location);
+      index.AddReference(named_type.name->sourceRange(), type_key);
+    }
+  }
+}
+
+[[maybe_unused]] void IndexParameter(
+    const slang::ast::ParameterSymbol& symbol, DefinitionIndex& index) {
+  const auto& loc = symbol.location;
+  SymbolKey key = SymbolKey::FromSourceLocation(loc);
+
+  if (const auto& symbol_syntax = symbol.getSyntax()) {
+    index.AddDefinition(key, symbol_syntax->sourceRange());
+  }
+
+  // Parameter type reference
+  const auto& declared_type = symbol.getDeclaredType();
+  if (const auto& type_syntax = declared_type->getTypeSyntax()) {
+    if (type_syntax->kind == slang::syntax::SyntaxKind::NamedType) {
+      const auto& named_type =
+          type_syntax->as<slang::syntax::NamedTypeSyntax>();
+      const auto& resolved_type = symbol.getType();
+      SymbolKey type_key =
+          SymbolKey::FromSourceLocation(resolved_type.location);
+      index.AddReference(named_type.name->sourceRange(), type_key);
+    }
+  }
+}
+
+[[maybe_unused]] void IndexPort(
+    const slang::ast::PortSymbol& port, DefinitionIndex& index) {
+  const auto& declared_type =
+      port.internalSymbol->as<slang::ast::ValueSymbol>().getDeclaredType();
+
+  SymbolKey key = SymbolKey::FromSourceLocation(port.getType().location);
+
+  // Port definition type reference
+  if (const auto& type_alias = declared_type->getTypeSyntax()) {
+    if (type_alias->kind == slang::syntax::SyntaxKind::NamedType) {
+      const auto& named_type = type_alias->as<slang::syntax::NamedTypeSyntax>();
+      const auto& name = named_type.name;
+      const auto& range = name->sourceRange();
+      index.AddReference(range, key);
+    }
+  }
+}
+
+[[maybe_unused]] void IndexNamedValue(
+    const slang::ast::NamedValueExpression& expr, DefinitionIndex& index) {
+  const auto& loc = expr.symbol.location;
+  const auto& range = expr.sourceRange;
+
+  SymbolKey key = SymbolKey::FromSourceLocation(loc);
+
+  index.AddReference(range, key);
+}
+
+[[maybe_unused]] void IndexStatementBlock(
+    const slang::ast::StatementBlockSymbol& symbol, DefinitionIndex& index) {
+  if (!symbol.name.empty()) {
+    SymbolKey key = SymbolKey::FromSourceLocation(symbol.location);
+    if (const auto* syntax = symbol.getSyntax()) {
+      if (syntax->kind == slang::syntax::SyntaxKind::SequentialBlockStatement ||
+          syntax->kind == slang::syntax::SyntaxKind::ParallelBlockStatement) {
+        const auto& block_syntax =
+            syntax->as<slang::syntax::BlockStatementSyntax>();
+        if (block_syntax.blockName != nullptr) {
+          index.AddDefinition(key, block_syntax.blockName->name.range());
+        }
+      }
+    }
+  }
+}
+
+}  // anonymous namespace
+
+auto DefinitionIndex::FromCompilation(
+    slang::ast::Compilation& compilation,
+    const std::unordered_set<slang::BufferID>& traverse_buffers,
+    std::shared_ptr<spdlog::logger> logger) -> DefinitionIndex {
+  DefinitionIndex index(compilation, logger);
+  auto visitor = slang::ast::makeVisitor(
+      // Special handling for instance body
+      [&](auto& self, const slang::ast::InstanceBodySymbol& symbol) {
+        self.visitDefault(symbol);
+      },
+
+      // Package definition visitor
+      [&](auto& self, const slang::ast::PackageSymbol& symbol) {
+        IndexPackage(symbol, index);
+
+        self.visitDefault(symbol);
+      },
+
+      // Module/interface definition visitor
+      [&](auto& self, const slang::ast::DefinitionSymbol& def) {
+        IndexDefinition(def, index, compilation);
+
+        // Check if we should traverse the instance body
+        auto def_buffer = def.location.buffer();
+        auto should_traverse =
+            traverse_buffers.find(def_buffer) != traverse_buffers.end();
+
+        if (should_traverse &&
+            (def.definitionKind == slang::ast::DefinitionKind::Module ||
+             def.definitionKind == slang::ast::DefinitionKind::Interface)) {
+          auto& instance =
+              slang::ast::InstanceSymbol::createInvalid(compilation, def);
+
+          // Set parent scope to enable port connection resolution
+          instance.setParent(compilation.getRoot());
+
+          // Trigger port connection resolution to create interface instances
+          instance.getPortConnections();
+
+          instance.body.visit(self);
+        }
+      },
+
+      // UninstantiatedDefSymbol visitor
+      [&](auto& self, const slang::ast::UninstantiatedDefSymbol& symbol) {
+        IndexUninstantiatedDef(symbol, index, compilation);
+        for (const auto& port_connection : symbol.getPortConnections()) {
+          if (port_connection != nullptr) {
+            port_connection->visit(self);
+          }
+        }
+        self.visitDefault(symbol);
+      },
+
+      // Type alias definition visitor
+      [&](auto& self, const slang::ast::TypeAliasType& symbol) {
+        IndexTypeAlias(symbol, index);
+        self.visitDefault(symbol);
+      },
+
+      // Variable definition visitor
+      [&](auto& self, const slang::ast::VariableSymbol& symbol) {
+        IndexVariable(symbol, index);
+        self.visitDefault(symbol);
+      },
+
+      // Parameter definition visitor
+      [&](auto& self, const slang::ast::ParameterSymbol& symbol) {
+        IndexParameter(symbol, index);
+        self.visitDefault(symbol);
+      },
+
+      // Port list type reference visitor
+      [&](auto& self, const slang::ast::PortSymbol& port) {
+        IndexPort(port, index);
+        self.visitDefault(port);
+      },
+
+      // Named value reference visitor
+      [&](auto& self, const slang::ast::NamedValueExpression& expr) {
+        IndexNamedValue(expr, index);
+        self.visitDefault(expr);
+      },
+
+      // Procedural block label visitor
+      [&](auto& self, const slang::ast::StatementBlockSymbol& symbol) {
+        IndexStatementBlock(symbol, index);
+        self.visitDefault(symbol);
+      });
+
+  // Visit all definitions
+  for (const auto* symbol : compilation.getDefinitions()) {
+    if (symbol != nullptr) {
+      symbol->visit(visitor);
+    }
+  }
+
+  // Visit all packages
+  for (const auto* package_symbol : compilation.getPackages()) {
+    if (package_symbol != nullptr) {
+      package_symbol->visit(visitor);
+    }
+  }
+
+  return index;
+}
+
+auto DefinitionIndex::LookupSymbolAt(slang::SourceLocation loc) const
+    -> std::optional<SymbolKey> {
+  for (const auto& [range, key] : reference_map_) {
+    if (range.contains(loc)) {
+      return key;
+    }
+  }
+  return std::nullopt;
+}
+
+auto DefinitionIndex::GetDefinitionRange(const SymbolKey& key) const
+    -> std::optional<slang::SourceRange> {
+  auto it = definition_locations_.find(key);
+  if (it != definition_locations_.end()) {
+    return it->second;
+  }
+  return std::nullopt;
+}
+
+auto DefinitionIndex::PrintInfo() const -> void {
+  logger_->info("DefinitionIndex info:");
+  logger_->info(
+      "  Definition locations size: {}", definition_locations_.size());
+  for (const auto& [key, range] : definition_locations_) {
+    logger_->info(
+        "    {}:{} -> {}:{}-{}:{}", key.bufferId, key.offset,
+        range.start().buffer().getId(), range.start().offset(),
+        range.end().buffer().getId(), range.end().offset());
+  }
+  logger_->info("  Reference map size: {}", reference_map_.size());
+  for (const auto& [range, key] : reference_map_) {
+    logger_->info(
+        "    {}:{}-{}:{} -> {}:{}", range.start().buffer().getId(),
+        range.start().offset(), range.end().buffer().getId(),
+        range.end().offset(), key.bufferId, key.offset);
+  }
+}
+
+}  // namespace slangd::semantic

--- a/src/slangd/semantic/diagnostic_index.cpp
+++ b/src/slangd/semantic/diagnostic_index.cpp
@@ -1,0 +1,216 @@
+#include "slangd/semantic/diagnostic_index.hpp"
+
+#include <slang/diagnostics/DiagnosticEngine.h>
+#include <slang/diagnostics/Diagnostics.h>
+
+#include "slangd/utils/conversion.hpp"
+#include "slangd/utils/path_utils.hpp"
+
+namespace slangd::semantic {
+
+auto DiagnosticIndex::FromCompilation(
+    slang::ast::Compilation& compilation,
+    const slang::SourceManager& source_manager, const std::string& uri,
+    std::shared_ptr<spdlog::logger> logger) -> DiagnosticIndex {
+  if (!logger) {
+    logger = spdlog::default_logger();
+  }
+
+  logger->debug("Creating DiagnosticIndex for: {}", uri);
+
+  // Extract diagnostics from compilation
+  auto diagnostics = ExtractDiagnosticsFromCompilation(
+      compilation, source_manager, uri, logger);
+
+  // Apply filtering and modification
+  auto filtered_diagnostics = FilterAndModifyDiagnostics(diagnostics, logger);
+
+  logger->debug(
+      "DiagnosticIndex created with {} diagnostics for: {}",
+      filtered_diagnostics.size(), uri);
+
+  return {std::move(filtered_diagnostics), uri, std::move(logger)};
+}
+
+DiagnosticIndex::DiagnosticIndex(
+    std::vector<lsp::Diagnostic> diagnostics, std::string uri,
+    std::shared_ptr<spdlog::logger> logger)
+    : diagnostics_(std::move(diagnostics)),
+      uri_(std::move(uri)),
+      logger_(std::move(logger)) {
+}
+
+auto DiagnosticIndex::PrintInfo() const -> void {
+  logger_->info(
+      "DiagnosticIndex for {}: {} diagnostics", uri_, diagnostics_.size());
+  for (const auto& diag : diagnostics_) {
+    int severity_value = static_cast<int>(
+        diag.severity.value_or(lsp::DiagnosticSeverity::kError));
+    logger_->info(
+        "  {} at {}:{}-{}:{}: {}", severity_value, diag.range.start.line,
+        diag.range.start.character, diag.range.end.line,
+        diag.range.end.character, diag.message);
+  }
+}
+
+auto DiagnosticIndex::ExtractDiagnosticsFromCompilation(
+    slang::ast::Compilation& compilation,
+    const slang::SourceManager& source_manager, const std::string& uri,
+    std::shared_ptr<spdlog::logger> logger) -> std::vector<lsp::Diagnostic> {
+  std::vector<lsp::Diagnostic> diagnostics;
+
+  // Create a diagnostic engine using the source manager
+  // This ensures proper location information for diagnostics
+  slang::DiagnosticEngine diagnostic_engine(source_manager);
+
+  // Disable unnamed-generate warnings by default: start with "none"
+  // then enable only the default group with "default"
+  std::vector<std::string> warning_options = {"none", "default"};
+  diagnostic_engine.setWarningOptions(warning_options);
+
+  // Extract semantic diagnostics from compilation
+  // This includes both syntax and semantic diagnostics
+  auto slang_diagnostics = compilation.getAllDiagnostics();
+
+  auto lsp_diagnostics = ConvertSlangDiagnosticsToLsp(
+      slang_diagnostics, source_manager, diagnostic_engine, uri);
+
+  logger->debug(
+      "Extracted {} diagnostics from compilation for: {}",
+      lsp_diagnostics.size(), uri);
+
+  return lsp_diagnostics;
+}
+
+auto DiagnosticIndex::FilterAndModifyDiagnostics(
+    std::vector<lsp::Diagnostic> diagnostics,
+    std::shared_ptr<spdlog::logger> logger) -> std::vector<lsp::Diagnostic> {
+  std::vector<lsp::Diagnostic> result;
+  result.reserve(diagnostics.size());
+
+  for (auto& diag : diagnostics) {
+    // 1. Check for diagnostics to completely exclude
+    if (diag.code == "InfoTask") {
+      // Skip these diagnostics entirely
+      continue;
+    }
+
+    // 2. Check for diagnostics to demote and enhance
+    if (diag.code == "CouldNotOpenIncludeFile") {
+      // Demote to warning
+      diag.severity = lsp::DiagnosticSeverity::kWarning;
+
+      // Replace original message with more helpful one
+      std::string original_path;
+      size_t quote_pos = diag.message.find('\'');
+      if (quote_pos != std::string::npos) {
+        size_t end_quote = diag.message.find('\'', quote_pos + 1);
+        if (end_quote != std::string::npos) {
+          original_path =
+              diag.message.substr(quote_pos, end_quote - quote_pos + 1);
+        }
+      }
+
+      if (!original_path.empty()) {
+        diag.message = "Cannot find include file " + original_path;
+      }
+
+      // Add hint about configuration
+      diag.message +=
+          " (Consider configuring include directories in a .slangd file)";
+    } else if (diag.code == "UnknownDirective") {
+      // Demote to warning
+      diag.severity = lsp::DiagnosticSeverity::kWarning;
+
+      // Add hint about configuration
+      diag.message += " (Add defines in .slangd file if needed)";
+    }
+
+    result.push_back(diag);
+  }
+
+  logger->debug(
+      "DiagnosticIndex filtered {} diagnostics",
+      diagnostics.size() - result.size());
+
+  return result;
+}
+
+auto DiagnosticIndex::ConvertSlangDiagnosticsToLsp(
+    const slang::Diagnostics& slang_diagnostics,
+    const slang::SourceManager& source_manager,
+    const slang::DiagnosticEngine& diag_engine, const std::string& uri)
+    -> std::vector<lsp::Diagnostic> {
+  std::vector<lsp::Diagnostic> result;
+
+  for (const auto& diag : slang_diagnostics) {
+    // Skip diagnostics not in our document
+    if (!IsDiagnosticInUriDocument(diag, source_manager, uri)) {
+      continue;
+    }
+
+    // Create the LSP diagnostic
+    lsp::Diagnostic lsp_diag;
+
+    // Get severity from the diagnostic engine
+    lsp_diag.severity = ConvertDiagnosticSeverityToLsp(
+        diag_engine.getSeverity(diag.code, diag.location));
+
+    // Format message using the diagnostic engine
+    lsp_diag.message = diag_engine.formatMessage(diag);
+
+    if (diag.ranges.size() > 0) {
+      // Explicitly select the first range
+      lsp_diag.range =
+          ConvertSlangRangeToLspRange(diag.ranges[0], source_manager);
+    }
+    // Convert location to range
+    else if (diag.location) {
+      lsp_diag.range =
+          ConvertSlangLocationToLspRange(diag.location, source_manager);
+    }
+    // Fallback to an empty range at the start of the file
+    else {
+      lsp_diag.range = lsp::Range{
+          .start = lsp::Position{.line = 0, .character = 0},
+          .end = lsp::Position{.line = 0, .character = 0}};
+    }
+
+    // Add optional code and source fields
+    lsp_diag.code = toString(diag.code);
+    lsp_diag.source = "slang";
+
+    result.push_back(lsp_diag);
+  }
+
+  return result;
+}
+
+// Helper functions - need to be static members to avoid linking issues
+auto DiagnosticIndex::ConvertDiagnosticSeverityToLsp(
+    slang::DiagnosticSeverity severity) -> lsp::DiagnosticSeverity {
+  switch (severity) {
+    case slang::DiagnosticSeverity::Ignored:
+      return lsp::DiagnosticSeverity::kHint;
+    case slang::DiagnosticSeverity::Note:
+      return lsp::DiagnosticSeverity::kInformation;
+    case slang::DiagnosticSeverity::Warning:
+      return lsp::DiagnosticSeverity::kWarning;
+    case slang::DiagnosticSeverity::Error:
+      return lsp::DiagnosticSeverity::kError;
+    case slang::DiagnosticSeverity::Fatal:
+      return lsp::DiagnosticSeverity::kError;
+  }
+}
+
+auto DiagnosticIndex::IsDiagnosticInUriDocument(
+    const slang::Diagnostic& diag, const slang::SourceManager& source_manager,
+    const std::string& uri) -> bool {
+  if (!diag.location) {
+    return false;
+  }
+
+  return IsLocationInDocument(diag.location, source_manager, uri);
+}
+
+}  // namespace slangd::semantic

--- a/src/slangd/semantic/symbol_index.cpp
+++ b/src/slangd/semantic/symbol_index.cpp
@@ -1,408 +1,427 @@
 #include "slangd/semantic/symbol_index.hpp"
 
-#include <spdlog/spdlog.h>
+#include <unordered_set>
 
-#include "slang/ast/ASTVisitor.h"
-#include "slang/ast/expressions/MiscExpressions.h"
-#include "slang/ast/symbols/CompilationUnitSymbols.h"
-#include "slang/ast/symbols/InstanceSymbols.h"
-#include "slang/syntax/AllSyntax.h"
+#include <slang/ast/Scope.h>
+#include <slang/ast/Symbol.h>
+#include <slang/ast/symbols/CompilationUnitSymbols.h>
+#include <slang/ast/symbols/InstanceSymbols.h>
+#include <slang/ast/symbols/MemberSymbols.h>
+#include <slang/ast/symbols/ParameterSymbols.h>
+#include <slang/ast/symbols/VariableSymbols.h>
+#include <slang/ast/types/AllTypes.h>
+#include <slang/ast/types/Type.h>
+#include <slang/text/SourceManager.h>
+
+#include "slangd/utils/conversion.hpp"
+#include "slangd/utils/path_utils.hpp"
 
 namespace slangd::semantic {
 
-void SymbolIndex::AddDefinition(
-    const SymbolKey& key, const slang::SourceRange& range) {
-  // Store the definition location
-  definition_locations_[key] = range;
-
-  // Also add the reference to the reference map
-  reference_map_[range] = key;
-}
-
-void SymbolIndex::AddReference(
-    const slang::SourceRange& range, const SymbolKey& key) {
-  reference_map_[range] = key;
-}
-
-namespace {
-// Indexing helper functions
-
-[[maybe_unused]] void IndexPackage(
-    const slang::ast::PackageSymbol& symbol, SymbolIndex& index) {
-  SymbolKey key = SymbolKey::FromSourceLocation(symbol.location);
-
-  if (const auto* syntax_node = symbol.getSyntax()) {
-    if (syntax_node->kind == slang::syntax::SyntaxKind::PackageDeclaration) {
-      // Module and package both use ModuleDeclarationSyntax
-      const auto& package_syntax =
-          syntax_node->as<slang::syntax::ModuleDeclarationSyntax>();
-
-      const auto& range = package_syntax.header->name.range();
-      index.AddDefinition(key, range);
-
-      // Handle endpackage name if present
-      if (const auto& end_name = package_syntax.blockName) {
-        index.AddReference(end_name->name.range(), key);
-      }
-    }
-  }
-}
-
-[[maybe_unused]] void IndexDefinition(
-    const slang::ast::DefinitionSymbol& def, SymbolIndex& index,
-    slang::ast::Compilation& compilation) {
-  const auto* syntax = def.getSyntax();
-  if ((syntax != nullptr) &&
-      syntax->kind == slang::syntax::SyntaxKind::ModuleDeclaration) {
-    // Add the definition to the index
-    const auto& module_syntax =
-        syntax->as<slang::syntax::ModuleDeclarationSyntax>();
-    const auto& module_range = module_syntax.header->name.range();
-    SymbolKey key = SymbolKey::FromSourceLocation(def.location);
-    index.AddDefinition(key, module_range);
-
-    // Add the endmodule label to the reference map
-    if (const auto& end_label = module_syntax.blockName) {
-      index.AddReference(end_label->name.range(), key);
-    }
-
-    // Handle imports
-    for (const auto& import_decl : module_syntax.header->imports) {
-      for (const auto& import_item : import_decl->items) {
-        if (import_item->kind == slang::syntax::SyntaxKind::PackageImportItem) {
-          const auto& import_syntax =
-              import_item->as<slang::syntax::PackageImportItemSyntax>();
-          auto package_range = import_syntax.package.range();
-          const auto& package_name = import_syntax.package.valueText();
-          const auto* package_symbol = compilation.getPackage(package_name);
-          if (package_symbol != nullptr) {
-            SymbolKey key =
-                SymbolKey::FromSourceLocation(package_symbol->location);
-            index.AddReference(package_range, key);
-          }
-        }
-      }
-    }
-  }
-}
-
-[[maybe_unused]] void IndexUninstantiatedDef(
-    const slang::ast::UninstantiatedDefSymbol& symbol, SymbolIndex& index,
-    slang::ast::Compilation& compilation) {
-  // Get the instance type location
-  slang::SourceRange instance_type_range;
-  if (symbol.getSyntax()->kind ==
-      slang::syntax::SyntaxKind::HierarchicalInstance) {
-    const auto& hierarchical_instance_syntax =
-        symbol.getSyntax()->as<slang::syntax::HierarchicalInstanceSyntax>();
-    // Try get parent and convert to HierarchicalInstantiationSyntax to get the
-    // type range
-    if (const auto* parent = hierarchical_instance_syntax.parent) {
-      if (parent->kind == slang::syntax::SyntaxKind::HierarchyInstantiation) {
-        instance_type_range =
-            parent->as<slang::syntax::HierarchyInstantiationSyntax>()
-                .type.range();
-      }
-    }
-  }
-
-  // Lookup for the module definition. If found, add the instance type to
-  // the reference map
-  const auto* scope = symbol.getParentScope();
-  if (scope != nullptr) {
-    auto module_def =
-        compilation.tryGetDefinition(symbol.definitionName, *scope);
-    if (module_def.definition != nullptr) {
-      const auto* syntax = module_def.definition->getSyntax();
-      if (syntax->kind == slang::syntax::SyntaxKind::ModuleDeclaration) {
-        const auto& module_syntax =
-            syntax->as<slang::syntax::ModuleDeclarationSyntax>();
-        auto module_def_location = module_syntax.header->name.range().start();
-        SymbolKey key = SymbolKey::FromSourceLocation(module_def_location);
-
-        index.AddReference(instance_type_range, key);
-      }
-    }
-  }
-
-  // Add the instance name to the definition map
-  if (const auto& symbol_syntax = symbol.getSyntax()) {
-    if (symbol_syntax->kind ==
-        slang::syntax::SyntaxKind::HierarchicalInstance) {
-      const auto& instance_syntax =
-          symbol_syntax->as<slang::syntax::HierarchicalInstanceSyntax>();
-
-      // Instance name definition
-      if (instance_syntax.decl != nullptr) {
-        SymbolKey key = SymbolKey::FromSourceLocation(symbol.location);
-        index.AddDefinition(key, instance_syntax.decl->name.range());
-      }
-    }
-  }
-}
-
-[[maybe_unused]] void IndexTypeAlias(
-    const slang::ast::TypeAliasType& symbol, SymbolIndex& index) {
-  const auto& loc = symbol.location;
-  SymbolKey key = SymbolKey::FromSourceLocation(loc);
-
-  if (const auto& symbol_syntax = symbol.getSyntax()) {
-    if (symbol_syntax->kind == slang::syntax::SyntaxKind::TypedefDeclaration) {
-      const auto& type_alias_syntax =
-          symbol_syntax->as<slang::syntax::TypedefDeclarationSyntax>();
-      index.AddDefinition(key, type_alias_syntax.name.range());
-    }
-  }
-
-  // If it's an enum type, process all enum values
-  if (symbol.targetType.getType().kind == slang::ast::SymbolKind::EnumType) {
-    const auto& enum_type =
-        symbol.targetType.getType().as<slang::ast::EnumType>();
-    for (const auto& enum_value : enum_type.values()) {
-      auto key = SymbolKey::FromSourceLocation(enum_value.location);
-      if (const auto& value_syntax = enum_value.getSyntax()) {
-        index.AddDefinition(key, value_syntax->sourceRange());
-      }
-    }
-  }
-}
-
-[[maybe_unused]] void IndexVariable(
-    const slang::ast::VariableSymbol& symbol, SymbolIndex& index) {
-  const auto& loc = symbol.location;
-  SymbolKey key = SymbolKey::FromSourceLocation(loc);
-
-  if (const auto& symbol_syntax = symbol.getSyntax()) {
-    index.AddDefinition(key, symbol_syntax->sourceRange());
-  }
-
-  // Variable type reference
-  const auto& declared_type = symbol.getDeclaredType();
-  if (const auto& type_syntax = declared_type->getTypeSyntax()) {
-    if (type_syntax->kind == slang::syntax::SyntaxKind::NamedType) {
-      const auto& named_type =
-          type_syntax->as<slang::syntax::NamedTypeSyntax>();
-      const auto& resolved_type = symbol.getType();
-      SymbolKey type_key =
-          SymbolKey::FromSourceLocation(resolved_type.location);
-      index.AddReference(named_type.name->sourceRange(), type_key);
-    }
-  }
-}
-
-[[maybe_unused]] void IndexParameter(
-    const slang::ast::ParameterSymbol& symbol, SymbolIndex& index) {
-  const auto& loc = symbol.location;
-  SymbolKey key = SymbolKey::FromSourceLocation(loc);
-
-  if (const auto& symbol_syntax = symbol.getSyntax()) {
-    index.AddDefinition(key, symbol_syntax->sourceRange());
-  }
-
-  // Parameter type reference
-  const auto& declared_type = symbol.getDeclaredType();
-  if (const auto& type_syntax = declared_type->getTypeSyntax()) {
-    if (type_syntax->kind == slang::syntax::SyntaxKind::NamedType) {
-      const auto& named_type =
-          type_syntax->as<slang::syntax::NamedTypeSyntax>();
-      const auto& resolved_type = symbol.getType();
-      SymbolKey type_key =
-          SymbolKey::FromSourceLocation(resolved_type.location);
-      index.AddReference(named_type.name->sourceRange(), type_key);
-    }
-  }
-}
-
-[[maybe_unused]] void IndexPort(
-    const slang::ast::PortSymbol& port, SymbolIndex& index) {
-  const auto& declared_type =
-      port.internalSymbol->as<slang::ast::ValueSymbol>().getDeclaredType();
-
-  SymbolKey key = SymbolKey::FromSourceLocation(port.getType().location);
-
-  // Port definition type reference
-  if (const auto& type_alias = declared_type->getTypeSyntax()) {
-    if (type_alias->kind == slang::syntax::SyntaxKind::NamedType) {
-      const auto& named_type = type_alias->as<slang::syntax::NamedTypeSyntax>();
-      const auto& name = named_type.name;
-      const auto& range = name->sourceRange();
-      index.AddReference(range, key);
-    }
-  }
-}
-
-[[maybe_unused]] void IndexNamedValue(
-    const slang::ast::NamedValueExpression& expr, SymbolIndex& index) {
-  const auto& loc = expr.symbol.location;
-  const auto& range = expr.sourceRange;
-
-  SymbolKey key = SymbolKey::FromSourceLocation(loc);
-
-  index.AddReference(range, key);
-}
-
-[[maybe_unused]] void IndexStatementBlock(
-    const slang::ast::StatementBlockSymbol& symbol, SymbolIndex& index) {
-  if (!symbol.name.empty()) {
-    SymbolKey key = SymbolKey::FromSourceLocation(symbol.location);
-    if (const auto* syntax = symbol.getSyntax()) {
-      if (syntax->kind == slang::syntax::SyntaxKind::SequentialBlockStatement ||
-          syntax->kind == slang::syntax::SyntaxKind::ParallelBlockStatement) {
-        const auto& block_syntax =
-            syntax->as<slang::syntax::BlockStatementSyntax>();
-        if (block_syntax.blockName != nullptr) {
-          index.AddDefinition(key, block_syntax.blockName->name.range());
-        }
-      }
-    }
-  }
-}
-
-}  // anonymous namespace
-
 auto SymbolIndex::FromCompilation(
     slang::ast::Compilation& compilation,
-    const std::unordered_set<slang::BufferID>& traverse_buffers,
-    std::shared_ptr<spdlog::logger> logger) -> SymbolIndex {
-  SymbolIndex index(compilation, logger);
-  auto visitor = slang::ast::makeVisitor(
-      // Special handling for instance body
-      [&](auto& self, const slang::ast::InstanceBodySymbol& symbol) {
-        self.visitDefault(symbol);
-      },
+    const slang::SourceManager& source_manager,
+    std::shared_ptr<spdlog::logger> logger) -> std::unique_ptr<SymbolIndex> {
+  return std::unique_ptr<SymbolIndex>(
+      new SymbolIndex(compilation, source_manager, logger));
+}
 
-      // Package definition visitor
-      [&](auto& self, const slang::ast::PackageSymbol& symbol) {
-        IndexPackage(symbol, index);
+SymbolIndex::SymbolIndex(
+    slang::ast::Compilation& compilation,
+    const slang::SourceManager& source_manager,
+    std::shared_ptr<spdlog::logger> logger)
+    : compilation_(compilation),
+      source_manager_(source_manager),
+      logger_(logger ? logger : spdlog::default_logger()) {
+}
 
-        self.visitDefault(symbol);
-      },
+auto SymbolIndex::GetDocumentSymbols(const std::string& uri) const
+    -> std::vector<lsp::DocumentSymbol> {
+  return ResolveSymbolsFromCompilation(uri);
+}
 
-      // Module/interface definition visitor
-      [&](auto& self, const slang::ast::DefinitionSymbol& def) {
-        IndexDefinition(def, index, compilation);
+auto SymbolIndex::ResolveSymbolsFromCompilation(const std::string& uri) const
+    -> std::vector<lsp::DocumentSymbol> {
+  std::vector<lsp::DocumentSymbol> result;
+  std::unordered_set<std::string> seen_names;
 
-        // Check if we should traverse the instance body
-        auto def_buffer = def.location.buffer();
-        auto should_traverse =
-            traverse_buffers.find(def_buffer) != traverse_buffers.end();
+  // Get top-level definitions (modules, interfaces, etc.)
+  for (const auto& def : compilation_.get().getDefinitions()) {
+    BuildSymbolHierarchy(GetUnwrappedSymbol(*def), result, uri, seen_names);
+  }
 
-        if (should_traverse &&
-            (def.definitionKind == slang::ast::DefinitionKind::Module ||
-             def.definitionKind == slang::ast::DefinitionKind::Interface)) {
-          auto& instance =
-              slang::ast::InstanceSymbol::createInvalid(compilation, def);
+  // Get packages
+  for (const auto& package : compilation_.get().getPackages()) {
+    BuildSymbolHierarchy(GetUnwrappedSymbol(*package), result, uri, seen_names);
+  }
 
-          // Set parent scope to enable port connection resolution
-          instance.setParent(compilation.getRoot());
+  return result;
+}
 
-          // Trigger port connection resolution to create interface instances
-          instance.getPortConnections();
+void SymbolIndex::BuildSymbolHierarchy(
+    const slang::ast::Symbol& symbol,
+    std::vector<lsp::DocumentSymbol>& document_symbols, const std::string& uri,
+    std::unordered_set<std::string>& seen_names) const {
+  // Only include symbols from the current document and with relevant kinds
+  if (!IsSymbolInUriDocument(symbol, source_manager_.get(), uri)) {
+    return;
+  }
 
-          instance.body.visit(self);
-        }
-      },
+  // Skip if we've seen this name already in current scope
+  if (seen_names.find(std::string(symbol.name)) != seen_names.end()) {
+    return;
+  }
 
-      // UninstantiatedDefSymbol visitor
-      [&](auto& self, const slang::ast::UninstantiatedDefSymbol& symbol) {
-        IndexUninstantiatedDef(symbol, index, compilation);
-        for (const auto& port_connection : symbol.getPortConnections()) {
-          if (port_connection != nullptr) {
-            port_connection->visit(self);
+  // Create a document symbol for this symbol
+  lsp::DocumentSymbol doc_symbol;
+  doc_symbol.name = std::string(symbol.name);
+
+  // Get the symbol kind from our mapping function
+  doc_symbol.kind = ConvertSymbolKindToLsp(symbol);
+
+  // Get the symbol's location range
+  if (symbol.location) {
+    doc_symbol.range =
+        ConvertSlangLocationToLspRange(symbol.location, source_manager_.get());
+    doc_symbol.selectionRange =
+        ConvertSymbolNameRangeToLsp(symbol, source_manager_.get());
+  }
+
+  // Add this symbol name to seen names in current scope to prevent duplicates
+  seen_names.insert(doc_symbol.name);
+
+  // Process children with type-specific traversal logic
+  doc_symbol.children = std::vector<lsp::DocumentSymbol>();
+  BuildSymbolChildren(symbol, doc_symbol, uri);
+
+  // Only add this symbol if it has a valid range or has children
+  if (symbol.location || doc_symbol.children->empty()) {
+    document_symbols.push_back(std::move(doc_symbol));
+  }
+}
+
+void SymbolIndex::BuildSymbolChildren(
+    const slang::ast::Symbol& symbol, lsp::DocumentSymbol& parent_symbol,
+    const std::string& uri) const {
+  using SK = slang::ast::SymbolKind;
+
+  // Handle different symbol types
+  if (symbol.kind == SK::Package) {
+    // Packages need special handling to reach their members
+    const auto& package = symbol.as<slang::ast::PackageSymbol>();
+    BuildScopeSymbolChildren(package, parent_symbol, uri);
+  } else if (symbol.kind == SK::Definition) {
+    const auto& definition_symbol = symbol.as<slang::ast::DefinitionSymbol>();
+    auto& inst_symbol = slang::ast::InstanceSymbol::createDefault(
+        compilation_.get(), definition_symbol);
+    const auto& body = inst_symbol.body;
+    if (body.isScope()) {
+      const auto& scope = body.as<slang::ast::Scope>();
+      BuildScopeSymbolChildren(scope, parent_symbol, uri);
+    }
+  } else if (symbol.kind == SK::TypeAlias) {
+    // Type aliases need to be unwrapped to process their members
+    const auto& type_alias = symbol.as<slang::ast::TypeAliasType>();
+    const auto& canonical_type = type_alias.getCanonicalType();
+
+    if (canonical_type.kind == SK::EnumType) {
+      // Special handling for enums - add enum values as children
+      const auto& enum_type = canonical_type.as<slang::ast::EnumType>();
+
+      // Create a separate scope for enum values to avoid name conflicts
+      std::unordered_set<std::string> enum_seen_names;
+
+      // Process all enum values from the enum type
+      for (const auto& enum_value : enum_type.values()) {
+        // Only check if the enum value is in the current document
+        // (we only check location, not symbol kind since we know it's an enum
+        // value)
+        if (IsSymbolInDocument(enum_value, source_manager_.get(), uri)) {
+          // Create a document symbol for this enum value
+          lsp::DocumentSymbol enum_value_symbol;
+          enum_value_symbol.name = std::string(enum_value.name);
+          enum_value_symbol.kind = lsp::SymbolKind::kEnumMember;
+
+          if (enum_value.location) {
+            enum_value_symbol.range = ConvertSlangLocationToLspRange(
+                enum_value.location, source_manager_.get());
+            enum_value_symbol.selectionRange =
+                ConvertSymbolNameRangeToLsp(enum_value, source_manager_.get());
           }
+
+          // Add empty children vector
+          enum_value_symbol.children = std::vector<lsp::DocumentSymbol>();
+
+          // Add to parent's children
+          parent_symbol.children->push_back(std::move(enum_value_symbol));
         }
-        self.visitDefault(symbol);
-      },
+      }
+    } else if (canonical_type.kind == SK::PackedStructType) {
+      const auto& struct_type =
+          canonical_type.as<slang::ast::PackedStructType>();
+      // Make sure to process all members of the struct
+      BuildScopeSymbolChildren(struct_type, parent_symbol, uri);
+    } else if (canonical_type.kind == SK::UnpackedStructType) {
+      const auto& struct_type =
+          canonical_type.as<slang::ast::UnpackedStructType>();
+      BuildScopeSymbolChildren(struct_type, parent_symbol, uri);
+    } else if (canonical_type.kind == SK::PackedUnionType) {
+      const auto& union_type = canonical_type.as<slang::ast::PackedUnionType>();
+      BuildScopeSymbolChildren(union_type, parent_symbol, uri);
+    } else if (canonical_type.kind == SK::UnpackedUnionType) {
+      const auto& union_type =
+          canonical_type.as<slang::ast::UnpackedUnionType>();
+      BuildScopeSymbolChildren(union_type, parent_symbol, uri);
+    }
+  }
+  // Process nested fields within structs and unions
+  else if (symbol.kind == SK::Field) {
+    const auto& field = symbol.as<slang::ast::FieldSymbol>();
+    const auto& type = field.getType();
+    if (type.kind == SK::PackedStructType) {
+      const auto& struct_type = type.as<slang::ast::PackedStructType>();
+      BuildScopeSymbolChildren(struct_type, parent_symbol, uri);
+    } else if (type.kind == SK::UnpackedStructType) {
+      const auto& struct_type = type.as<slang::ast::UnpackedStructType>();
+      BuildScopeSymbolChildren(struct_type, parent_symbol, uri);
+    } else if (type.kind == SK::PackedUnionType) {
+      const auto& union_type = type.as<slang::ast::PackedUnionType>();
+      BuildScopeSymbolChildren(union_type, parent_symbol, uri);
+    } else if (type.kind == SK::UnpackedUnionType) {
+      const auto& union_type = type.as<slang::ast::UnpackedUnionType>();
+      BuildScopeSymbolChildren(union_type, parent_symbol, uri);
+    }
+  }
+  // For all other symbol types, don't traverse
+}
 
-      // Type alias definition visitor
-      [&](auto& self, const slang::ast::TypeAliasType& symbol) {
-        IndexTypeAlias(symbol, index);
-        self.visitDefault(symbol);
-      },
+void SymbolIndex::BuildScopeSymbolChildren(
+    const slang::ast::Scope& scope, lsp::DocumentSymbol& parent_symbol,
+    const std::string& uri) const {
+  // Each scope gets its own set of seen names
+  std::unordered_set<std::string> scope_seen_names;
 
-      // Variable definition visitor
-      [&](auto& self, const slang::ast::VariableSymbol& symbol) {
-        IndexVariable(symbol, index);
-        self.visitDefault(symbol);
-      },
+  // Process all members (enum values are filtered out by IsSymbolInUriDocument)
+  for (const auto& member : scope.members()) {
+    // Unwrap at the boundary before passing to BuildSymbolHierarchy
+    const auto& unwrapped_member = GetUnwrappedSymbol(member);
 
-      // Parameter definition visitor
-      [&](auto& self, const slang::ast::ParameterSymbol& symbol) {
-        IndexParameter(symbol, index);
-        self.visitDefault(symbol);
-      },
+    std::vector<lsp::DocumentSymbol> child_symbols;
+    BuildSymbolHierarchy(
+        unwrapped_member, child_symbols, uri, scope_seen_names);
+    for (auto& child : child_symbols) {
+      parent_symbol.children->push_back(std::move(child));
+    }
+  }
+}
 
-      // Port list type reference visitor
-      [&](auto& self, const slang::ast::PortSymbol& port) {
-        IndexPort(port, index);
-        self.visitDefault(port);
-      },
+auto SymbolIndex::ConvertSymbolKindToLsp(const slang::ast::Symbol& symbol)
+    -> lsp::SymbolKind {
+  using SK = slang::ast::SymbolKind;
+  using LK = lsp::SymbolKind;
+  using DK = slang::ast::DefinitionKind;
 
-      // Named value reference visitor
-      [&](auto& self, const slang::ast::NamedValueExpression& expr) {
-        IndexNamedValue(expr, index);
-        self.visitDefault(expr);
-      },
+  // if is type alias, need to get the canonical type and use that to determine
+  // the symbol kind
+  if (symbol.kind == SK::TypeAlias) {
+    const auto& type_alias = symbol.as<slang::ast::TypeAliasType>();
+    const auto& canonical_type = type_alias.getCanonicalType();
 
-      // Procedural block label visitor
-      [&](auto& self, const slang::ast::StatementBlockSymbol& symbol) {
-        IndexStatementBlock(symbol, index);
-        self.visitDefault(symbol);
-      });
-
-  // Visit all definitions
-  for (const auto* symbol : compilation.getDefinitions()) {
-    if (symbol != nullptr) {
-      symbol->visit(visitor);
+    switch (canonical_type.kind) {
+      case SK::EnumType:
+        return LK::kEnum;
+      case SK::PackedStructType:
+      case SK::UnpackedStructType:
+      case SK::PackedUnionType:
+      case SK::UnpackedUnionType:
+        return LK::kStruct;
+      default:
+        return LK::kTypeParameter;
     }
   }
 
-  // Visit all packages
-  for (const auto* package_symbol : compilation.getPackages()) {
-    if (package_symbol != nullptr) {
-      package_symbol->visit(visitor);
+  if (symbol.kind == SK::Definition) {
+    const auto& definition = symbol.as<slang::ast::DefinitionSymbol>();
+    if (definition.definitionKind == DK::Module) {
+      // In SystemVerilog, a 'module' defines encapsulated hardware with ports
+      // and internal logic. However, in software terms, it behaves more like a
+      // 'class': it has state, methods (processes), and can be instantiated
+      // multiple times. It's not just a namespace or file like software
+      // modules.
+      return LK::kClass;
+    }
+    if (definition.definitionKind == DK::Interface) {
+      return LK::kInterface;
     }
   }
 
-  return index;
+  // For non-Definition symbols, use a switch on the symbol kind
+  switch (symbol.kind) {
+    // Package
+    case SK::Package:
+      return LK::kPackage;
+
+    // Variables and data
+    case SK::Variable:
+    case SK::Net:
+    case SK::Port:
+    case SK::Instance:
+    case SK::UninstantiatedDef:
+      return LK::kVariable;
+
+    case SK::Field:
+    case SK::ClassProperty:
+      return LK::kField;
+
+    case SK::Parameter:
+    case SK::EnumValue:
+      return LK::kConstant;
+
+    case SK::TypeParameter:
+      return LK::kTypeParameter;
+
+    // Type-related
+    case SK::TypeAlias:
+    case SK::ForwardingTypedef:
+      return LK::kTypeParameter;
+
+    case SK::EnumType:
+      return LK::kEnum;
+
+    case SK::PackedStructType:
+    case SK::UnpackedStructType:
+      return LK::kStruct;
+
+    case SK::PackedUnionType:
+    case SK::UnpackedUnionType:
+      return LK::kClass;
+
+    case SK::ClassType:
+      return LK::kClass;
+
+    // Interface-related
+    case SK::Modport:
+      return LK::kInterface;
+
+    // Function-related
+    case SK::Subroutine:
+      return LK::kFunction;
+
+    // Default for other symbol kinds
+    default:
+      return LK::kObject;
+  }
 }
 
-auto SymbolIndex::LookupSymbolAt(slang::SourceLocation loc) const
-    -> std::optional<SymbolKey> {
-  for (const auto& [range, key] : reference_map_) {
-    if (range.contains(loc)) {
-      return key;
-    }
-  }
-  return std::nullopt;
+auto SymbolIndex::ConvertSymbolNameRangeToLsp(
+    const slang::ast::Symbol& symbol,
+    const slang::SourceManager& source_manager) -> lsp::Range {
+  // Just use the symbol's declaration location
+  return ConvertSlangLocationToLspRange(symbol.location, source_manager);
 }
 
-auto SymbolIndex::GetDefinitionRange(const SymbolKey& key) const
-    -> std::optional<slang::SourceRange> {
-  auto it = definition_locations_.find(key);
-  if (it != definition_locations_.end()) {
-    return it->second;
+auto SymbolIndex::IsSymbolInDocument(
+    const slang::ast::Symbol& symbol,
+    const slang::SourceManager& source_manager, const std::string& uri)
+    -> bool {
+  // Skip symbols without a valid location
+  if (!symbol.location) {
+    return false;
   }
-  return std::nullopt;
+
+  // Skip unnamed symbols
+  if (symbol.name.empty()) {
+    return false;
+  }
+
+  // Skip symbols that are compiler-generated (no source location)
+  if (source_manager.isPreprocessedLoc(symbol.location)) {
+    return false;
+  }
+
+  // Check if the symbol is from the current document using our utility
+  return IsLocationInDocument(symbol.location, source_manager, uri);
 }
 
-auto SymbolIndex::PrintInfo() const -> void {
-  logger_->info("SymbolIndex info:");
-  logger_->info(
-      "  Definition locations size: {}", definition_locations_.size());
-  for (const auto& [key, range] : definition_locations_) {
-    logger_->info(
-        "    {}:{} -> {}:{}-{}:{}", key.bufferId, key.offset,
-        range.start().buffer().getId(), range.start().offset(),
-        range.end().buffer().getId(), range.end().offset());
+auto SymbolIndex::IsRelevantDocumentSymbol(const slang::ast::Symbol& symbol)
+    -> bool {
+  using SK = slang::ast::SymbolKind;
+
+  // Include only specific types of symbols that are relevant to users
+  switch (symbol.kind) {
+    // Top-level design elements
+    case SK::Package:
+    case SK::Definition:
+      return true;
+
+    // Types
+    case SK::TypeAlias:
+    case SK::EnumType:
+    case SK::PackedStructType:
+    case SK::UnpackedStructType:
+    case SK::PackedUnionType:
+    case SK::UnpackedUnionType:
+    case SK::ClassType:
+      return true;
+
+    // Functions and Tasks
+    case SK::Subroutine:
+      return true;
+
+    // Important declarations
+    case SK::Parameter:
+    case SK::TypeParameter:
+    case SK::Modport:
+      return true;
+
+    // For variables, only include ports and parameters
+    case SK::Port:
+    case SK::Variable:
+    case SK::Net:
+    case SK::Instance:
+      return true;
+
+    // For struct fields, include them
+    case SK::Field:
+      return true;
+
+    // For uninstantiated definitions, include them
+    case SK::UninstantiatedDef:
+      return true;
+
+    // Explicitly exclude enum values - they'll be handled through their parent
+    // enum types
+    case SK::EnumValue:
+      return false;
+
+    // Default: exclude other symbols
+    default:
+      return false;
   }
-  logger_->info("  Reference map size: {}", reference_map_.size());
-  for (const auto& [range, key] : reference_map_) {
-    logger_->info(
-        "    {}:{}-{}:{} -> {}:{}", range.start().buffer().getId(),
-        range.start().offset(), range.end().buffer().getId(),
-        range.end().offset(), key.bufferId, key.offset);
+}
+
+auto SymbolIndex::IsSymbolInUriDocument(
+    const slang::ast::Symbol& symbol,
+    const slang::SourceManager& source_manager, const std::string& uri)
+    -> bool {
+  // Combine both checks
+  return IsSymbolInDocument(symbol, source_manager, uri) &&
+         IsRelevantDocumentSymbol(symbol);
+}
+
+// Helper function to unwrap TransparentMember symbols
+auto SymbolIndex::GetUnwrappedSymbol(const slang::ast::Symbol& symbol)
+    -> const slang::ast::Symbol& {
+  using SK = slang::ast::SymbolKind;
+
+  // If not a TransparentMember, return directly
+  if (symbol.kind != SK::TransparentMember) {
+    return symbol;
   }
+
+  // Recursively unwrap
+  return GetUnwrappedSymbol(
+      symbol.as<slang::ast::TransparentMemberSymbol>().wrapped);
 }
 
 }  // namespace slangd::semantic

--- a/src/slangd/services/legacy/diagnostics_provider.cpp
+++ b/src/slangd/services/legacy/diagnostics_provider.cpp
@@ -134,12 +134,12 @@ auto DiagnosticsProvider::ConvertDiagnosticsToLsp(
     if (diag.ranges.size() > 0) {
       // Explicitly select the first range
       lsp_diag.range =
-          ConvertSlangRangeToLspRange(diag.ranges[0], source_manager);
+          ConvertSlangRangeToLspRange(diag.ranges[0], *source_manager);
     }
     // Convert location to range
     else if (diag.location) {
       lsp_diag.range =
-          ConvertSlangLocationToLspRange(diag.location, source_manager);
+          ConvertSlangLocationToLspRange(diag.location, *source_manager);
     }
     // Fallback to an empty range at the start of the file
     else {
@@ -182,7 +182,7 @@ auto DiagnosticsProvider::IsDiagnosticInUriDocument(
     return false;
   }
 
-  return IsLocationInDocument(diag.location, source_manager, uri);
+  return IsLocationInDocument(diag.location, *source_manager, uri);
 }
 
 auto DiagnosticsProvider::FilterAndModifyDiagnostics(

--- a/src/slangd/services/legacy/document_manager.cpp
+++ b/src/slangd/services/legacy/document_manager.cpp
@@ -88,8 +88,8 @@ auto DocumentManager::ParseWithCompilation(std::string uri, std::string content)
   compilation.addSyntaxTree(syntax_trees_[path]);
 
   // Build a basic symbol index (definitions only) for quick navigation
-  symbol_indices_[path] = std::make_shared<semantic::SymbolIndex>(
-      semantic::SymbolIndex::FromCompilation(
+  symbol_indices_[path] = std::make_shared<semantic::DefinitionIndex>(
+      semantic::DefinitionIndex::FromCompilation(
           compilation, {buffer.id}, logger_));
 
   logger_->debug("DocumentManager compilation completed for document: {}", uri);
@@ -168,8 +168,8 @@ auto DocumentManager::MaybeRebuildIfLayoutChanged() -> asio::awaitable<void> {
   co_return;
 }
 
-auto DocumentManager::GetSymbolIndex(std::string uri)
-    -> std::shared_ptr<semantic::SymbolIndex> {
+auto DocumentManager::GetDefinitionIndex(std::string uri)
+    -> std::shared_ptr<semantic::DefinitionIndex> {
   auto path = CanonicalPath::FromUri(uri);
   auto it = symbol_indices_.find(path);
   if (it != symbol_indices_.end()) {

--- a/src/slangd/services/legacy/legacy_language_service.cpp
+++ b/src/slangd/services/legacy/legacy_language_service.cpp
@@ -41,7 +41,7 @@ auto LegacyLanguageService::InitializeWorkspace(std::string workspace_uri)
 }
 
 auto LegacyLanguageService::ComputeDiagnostics(
-    std::string uri, std::string content)
+    std::string uri, std::string content, int version)
     -> asio::awaitable<std::vector<lsp::Diagnostic>> {
   // Check if workspace is initialized
   if (!document_manager_) {
@@ -80,7 +80,9 @@ auto LegacyLanguageService::ComputeDiagnostics(
 }
 
 auto LegacyLanguageService::GetDefinitionsForPosition(
-    std::string uri, lsp::Position position) -> std::vector<lsp::Location> {
+    std::string uri, lsp::Position position,
+    [[maybe_unused]] std::string content, [[maybe_unused]] int version)
+    -> std::vector<lsp::Location> {
   // Check if workspace is initialized
   if (!document_manager_) {
     logger_->error("LegacyLanguageService: Workspace not initialized");
@@ -93,8 +95,9 @@ auto LegacyLanguageService::GetDefinitionsForPosition(
   return temp_provider.GetDefinitionForUri(uri, position);
 }
 
-auto LegacyLanguageService::GetDocumentSymbols(std::string uri)
-    -> std::vector<lsp::DocumentSymbol> {
+auto LegacyLanguageService::GetDocumentSymbols(
+    std::string uri, [[maybe_unused]] std::string content,
+    [[maybe_unused]] int version) -> std::vector<lsp::DocumentSymbol> {
   // Check if workspace is initialized
   if (!document_manager_) {
     logger_->error("LegacyLanguageService: Workspace not initialized");

--- a/src/slangd/services/legacy/workspace_manager.cpp
+++ b/src/slangd/services/legacy/workspace_manager.cpp
@@ -75,7 +75,7 @@ auto WorkspaceManager::AddOpenFile(CanonicalPath path)
   if (it != buffer_ids_.end()) {
     slang::BufferID buffer_id = it->second;
     open_buffers_.insert(buffer_id);
-    RebuildSymbolIndex();
+    RebuildDefinitionIndex();
   } else {
     logger_->warn(
         "WorkspaceManager attempted to open file without registered buffer: {}",
@@ -101,7 +101,7 @@ auto WorkspaceManager::MaybeRebuildIfLayoutChanged() -> asio::awaitable<void> {
     LoadAndCompileFiles(cached_layout_->GetFiles());
 
     // Rebuild symbol index after new compilation
-    RebuildSymbolIndex();
+    RebuildDefinitionIndex();
   }
 }
 
@@ -163,7 +163,7 @@ auto WorkspaceManager::ScanWorkspace() -> asio::awaitable<void> {
 
   // Ensure the workspace symbol index is built
   if (!symbol_index_) {
-    RebuildSymbolIndex();
+    RebuildDefinitionIndex();
   }
 
   logger_->debug(
@@ -215,11 +215,11 @@ auto WorkspaceManager::HandleFileChanges(std::vector<lsp::FileEvent> changes)
   co_return;
 }
 
-void WorkspaceManager::RebuildSymbolIndex() {
+void WorkspaceManager::RebuildDefinitionIndex() {
   logger_->debug("WorkspaceManager rebuilding symbol index");
   if (compilation_) {
-    symbol_index_ = std::make_shared<semantic::SymbolIndex>(
-        semantic::SymbolIndex::FromCompilation(
+    symbol_index_ = std::make_shared<semantic::DefinitionIndex>(
+        semantic::DefinitionIndex::FromCompilation(
             *compilation_, open_buffers_, logger_));
   }
 }
@@ -411,7 +411,7 @@ auto WorkspaceManager::RebuildWorkspaceCompilation() -> asio::awaitable<void> {
   compilation_ = new_compilation;
 
   // Build a workspace symbol index
-  RebuildSymbolIndex();
+  RebuildDefinitionIndex();
 
   // Validate state to ensure consistency
   if (!ValidateState()) {

--- a/src/slangd/services/new/new_language_service.cpp
+++ b/src/slangd/services/new/new_language_service.cpp
@@ -1,0 +1,156 @@
+#include "slangd/services/new/new_language_service.hpp"
+
+#include <slang/diagnostics/DiagnosticEngine.h>
+#include <slang/syntax/SyntaxTree.h>
+
+#include "slangd/services/legacy/diagnostics_provider.hpp"
+#include "slangd/utils/canonical_path.hpp"
+
+namespace slangd::services::new_service {
+
+NewLanguageService::NewLanguageService(
+    asio::any_io_executor executor, std::shared_ptr<spdlog::logger> logger)
+    : global_catalog_(nullptr),  // Phase 1a: no catalog yet
+      logger_(logger ? logger : spdlog::default_logger()),
+      executor_(std::move(executor)) {
+  logger_->debug("NewLanguageService created");
+}
+
+auto NewLanguageService::InitializeWorkspace(std::string workspace_uri)
+    -> asio::awaitable<void> {
+  logger_->debug(
+      "NewLanguageService initializing workspace: {}", workspace_uri);
+
+  // Create project layout service
+  auto workspace_path = CanonicalPath::FromUri(workspace_uri);
+  layout_service_ =
+      ProjectLayoutService::Create(executor_, workspace_path, logger_);
+  co_await layout_service_->LoadConfig(workspace_path);
+
+  // Phase 1a: global_catalog_ remains nullptr
+  // Phase 2 will initialize GlobalCatalog here
+
+  logger_->debug("NewLanguageService workspace initialized: {}", workspace_uri);
+}
+
+auto NewLanguageService::ComputeDiagnostics(
+    std::string uri, std::string content)
+    -> asio::awaitable<std::vector<lsp::Diagnostic>> {
+  if (!layout_service_) {
+    logger_->error("NewLanguageService: Workspace not initialized");
+    co_return std::vector<lsp::Diagnostic>{};
+  }
+
+  logger_->debug("NewLanguageService computing diagnostics for: {}", uri);
+
+  // Create overlay session for this request
+  auto session = CreateOverlaySession(uri, content);
+  if (!session) {
+    logger_->error("Failed to create overlay session for: {}", uri);
+    co_return std::vector<lsp::Diagnostic>{};
+  }
+
+  // Convert Slang diagnostics to LSP format
+  auto diagnostics = ConvertSlangDiagnosticsToLsp(
+      session->GetCompilation(), session->GetSourceManager(), uri);
+
+  logger_->debug(
+      "NewLanguageService computed {} diagnostics for: {}", diagnostics.size(),
+      uri);
+
+  co_return diagnostics;
+}
+
+auto NewLanguageService::GetDefinitionsForPosition(
+    std::string uri, lsp::Position position) -> std::vector<lsp::Location> {
+  if (!layout_service_) {
+    logger_->error("NewLanguageService: Workspace not initialized");
+    return {};
+  }
+
+  logger_->debug(
+      "NewLanguageService getting definitions for: {} at {}:{}", uri,
+      position.line, position.character);
+
+  // Phase 1a: Basic stub - will be implemented in Phase 1b
+  // TODO(hankhsu): Create overlay session and use SymbolIndex for lookups
+  logger_->debug("GetDefinitionsForPosition: Implementation pending Phase 1b");
+  return {};
+}
+
+auto NewLanguageService::GetDocumentSymbols(std::string uri)
+    -> std::vector<lsp::DocumentSymbol> {
+  if (!layout_service_) {
+    logger_->error("NewLanguageService: Workspace not initialized");
+    return {};
+  }
+
+  logger_->debug("NewLanguageService getting document symbols for: {}", uri);
+
+  // Phase 1a: Basic stub - will be implemented in Phase 1b
+  // TODO(hankhsu): Create overlay session and extract symbols from SymbolIndex
+  logger_->debug("GetDocumentSymbols: Implementation pending Phase 1b");
+  return {};
+}
+
+auto NewLanguageService::HandleConfigChange() -> void {
+  if (layout_service_) {
+    layout_service_->RebuildLayout();
+    logger_->debug("NewLanguageService handled config change");
+  }
+}
+
+auto NewLanguageService::HandleSourceFileChange() -> void {
+  if (layout_service_) {
+    layout_service_->ScheduleDebouncedRebuild();
+    logger_->debug("NewLanguageService handled source file change");
+  }
+}
+
+auto NewLanguageService::CreateOverlaySession(
+    std::string uri, std::string content)
+    -> std::unique_ptr<overlay::OverlaySession> {
+  return overlay::OverlaySession::Create(
+      uri, content, layout_service_, global_catalog_, logger_);
+}
+
+auto NewLanguageService::ConvertSlangDiagnosticsToLsp(
+    const slang::ast::Compilation& compilation,
+    const slang::SourceManager& source_manager, const std::string& uri)
+    -> std::vector<lsp::Diagnostic> {
+  // Phase 1a: Stub implementation - basic diagnostics only
+  // Will be properly implemented in Phase 1b using existing DiagnosticsProvider
+
+  // For now, return basic syntax diagnostics by using the compilation
+  // Create shared pointers for compatibility with existing code
+  auto compilation_ptr = std::shared_ptr<slang::ast::Compilation>(
+      const_cast<slang::ast::Compilation*>(&compilation), [](auto*) {});
+  auto source_manager_ptr = std::shared_ptr<slang::SourceManager>(
+      const_cast<slang::SourceManager*>(&source_manager), [](auto*) {});
+
+  // Use existing static method from DiagnosticsProvider
+  return DiagnosticsProvider::ResolveDiagnosticsFromCompilation(
+      compilation_ptr, nullptr, source_manager_ptr, uri);
+}
+
+auto NewLanguageService::ConvertSymbolIndexToLspLocations(
+    const semantic::SymbolIndex& symbol_index,
+    const slang::SourceManager& source_manager,
+    const semantic::SymbolKey& symbol_key) -> std::vector<lsp::Location> {
+  // Phase 1a: Stub - will be implemented in Phase 1b
+  logger_->debug(
+      "ConvertSymbolIndexToLspLocations: Implementation pending Phase 1b");
+  return {};
+}
+
+auto NewLanguageService::ExtractDocumentSymbolsFromIndex(
+    const semantic::SymbolIndex& symbol_index,
+    const slang::SourceManager& source_manager, const std::string& uri)
+    -> std::vector<lsp::DocumentSymbol> {
+  // Phase 1a: Stub - will be implemented in Phase 1b
+  logger_->debug(
+      "ExtractDocumentSymbolsFromIndex: Implementation pending Phase 1b");
+  return {};
+}
+
+}  // namespace slangd::services::new_service

--- a/src/slangd/services/new/new_language_service.cpp
+++ b/src/slangd/services/new/new_language_service.cpp
@@ -1,5 +1,7 @@
 #include "slangd/services/new/new_language_service.hpp"
 
+#include <algorithm>
+
 #include <slang/ast/symbols/CompilationUnitSymbols.h>
 #include <slang/diagnostics/DiagnosticEngine.h>
 #include <slang/syntax/SyntaxTree.h>
@@ -35,7 +37,7 @@ auto NewLanguageService::InitializeWorkspace(std::string workspace_uri)
 }
 
 auto NewLanguageService::ComputeDiagnostics(
-    std::string uri, std::string content)
+    std::string uri, std::string content, int version)
     -> asio::awaitable<std::vector<lsp::Diagnostic>> {
   if (!layout_service_) {
     logger_->error("NewLanguageService: Workspace not initialized");
@@ -44,8 +46,16 @@ auto NewLanguageService::ComputeDiagnostics(
 
   logger_->debug("NewLanguageService computing diagnostics for: {}", uri);
 
-  // Create overlay session for this request
-  auto session = CreateOverlaySession(uri, content);
+  // Create cache key with catalog version
+  uint64_t catalog_version =
+      global_catalog_ ? global_catalog_->GetVersion() : 0;
+  OverlayCacheKey cache_key{
+      .doc_uri = uri,
+      .doc_version = version,
+      .catalog_version = catalog_version};
+
+  // Get or create overlay session from cache
+  auto session = GetOrCreateOverlay(cache_key, content);
   if (!session) {
     logger_->error("Failed to create overlay session for: {}", uri);
     co_return std::vector<lsp::Diagnostic>{};
@@ -62,7 +72,8 @@ auto NewLanguageService::ComputeDiagnostics(
 }
 
 auto NewLanguageService::GetDefinitionsForPosition(
-    std::string uri, lsp::Position position) -> std::vector<lsp::Location> {
+    std::string uri, lsp::Position position, std::string content, int version)
+    -> std::vector<lsp::Location> {
   if (!layout_service_) {
     logger_->error("NewLanguageService: Workspace not initialized");
     return {};
@@ -72,10 +83,16 @@ auto NewLanguageService::GetDefinitionsForPosition(
       "NewLanguageService getting definitions for: {} at {}:{}", uri,
       position.line, position.character);
 
-  // Create overlay session for this request
-  // Note: We need the current buffer content, but since this is sync method,
-  // we'll use empty content for now (this should be improved in the future)
-  auto session = CreateOverlaySession(uri, "");
+  // Create cache key with catalog version
+  uint64_t catalog_version =
+      global_catalog_ ? global_catalog_->GetVersion() : 0;
+  OverlayCacheKey cache_key{
+      .doc_uri = uri,
+      .doc_version = version,
+      .catalog_version = catalog_version};
+
+  // Get or create overlay session from cache
+  auto session = GetOrCreateOverlay(cache_key, content);
   if (!session) {
     logger_->error("Failed to create overlay session for: {}", uri);
     return {};
@@ -124,7 +141,8 @@ auto NewLanguageService::GetDefinitionsForPosition(
   return {lsp_location};
 }
 
-auto NewLanguageService::GetDocumentSymbols(std::string uri)
+auto NewLanguageService::GetDocumentSymbols(
+    std::string uri, std::string content, int version)
     -> std::vector<lsp::DocumentSymbol> {
   if (!layout_service_) {
     logger_->error("NewLanguageService: Workspace not initialized");
@@ -133,8 +151,16 @@ auto NewLanguageService::GetDocumentSymbols(std::string uri)
 
   logger_->debug("NewLanguageService getting document symbols for: {}", uri);
 
-  // Create overlay session for this request
-  auto session = CreateOverlaySession(uri, "");
+  // Create cache key with catalog version
+  uint64_t catalog_version =
+      global_catalog_ ? global_catalog_->GetVersion() : 0;
+  OverlayCacheKey cache_key{
+      .doc_uri = uri,
+      .doc_version = version,
+      .catalog_version = catalog_version};
+
+  // Get or create overlay session from cache
+  auto session = GetOrCreateOverlay(cache_key, content);
   if (!session) {
     logger_->error("Failed to create overlay session for: {}", uri);
     return {};
@@ -147,6 +173,8 @@ auto NewLanguageService::GetDocumentSymbols(std::string uri)
 auto NewLanguageService::HandleConfigChange() -> void {
   if (layout_service_) {
     layout_service_->RebuildLayout();
+    // Clear cache when layout changes (catalog version will change)
+    ClearCache();
     logger_->debug("NewLanguageService handled config change");
   }
 }
@@ -154,15 +182,79 @@ auto NewLanguageService::HandleConfigChange() -> void {
 auto NewLanguageService::HandleSourceFileChange() -> void {
   if (layout_service_) {
     layout_service_->ScheduleDebouncedRebuild();
+    // Clear cache when layout changes (catalog version will change)
+    ClearCache();
     logger_->debug("NewLanguageService handled source file change");
   }
 }
 
 auto NewLanguageService::CreateOverlaySession(
     std::string uri, std::string content)
-    -> std::unique_ptr<overlay::OverlaySession> {
+    -> std::shared_ptr<overlay::OverlaySession> {
   return overlay::OverlaySession::Create(
       uri, content, layout_service_, global_catalog_, logger_);
+}
+
+auto NewLanguageService::GetOrCreateOverlay(
+    const OverlayCacheKey& key, const std::string& content)
+    -> std::shared_ptr<overlay::OverlaySession> {
+  auto now = std::chrono::steady_clock::now();
+
+  // Check if we already have this overlay in cache
+  for (auto& entry : overlay_cache_) {
+    if (entry.key == key) {
+      // Cache hit! Update access time and return
+      entry.last_access = now;
+      logger_->debug(
+          "Overlay cache hit for {}:v{}", key.doc_uri, key.doc_version);
+      return entry.session;
+    }
+  }
+
+  // Cache miss - create new overlay session
+  logger_->debug(
+      "Overlay cache miss for {}:v{} - creating new session", key.doc_uri,
+      key.doc_version);
+
+  auto shared_session = CreateOverlaySession(key.doc_uri, content);
+  if (!shared_session) {
+    logger_->error(
+        "Failed to create overlay session for {}:v{}", key.doc_uri,
+        key.doc_version);
+    return nullptr;
+  }
+
+  // Add to cache
+  CacheEntry entry{.key = key, .session = shared_session, .last_access = now};
+
+  // If cache is full, remove oldest entry (simple LRU)
+  if (overlay_cache_.size() >= kMaxCacheSize) {
+    // Find oldest entry
+    auto oldest_it = std::min_element(
+        overlay_cache_.begin(), overlay_cache_.end(),
+        [](const CacheEntry& a, const CacheEntry& b) {
+          return a.last_access < b.last_access;
+        });
+
+    if (oldest_it != overlay_cache_.end()) {
+      logger_->debug(
+          "Evicting oldest overlay from cache: {}:v{}", oldest_it->key.doc_uri,
+          oldest_it->key.doc_version);
+      *oldest_it = std::move(entry);
+    }
+  } else {
+    overlay_cache_.push_back(std::move(entry));
+  }
+
+  logger_->debug(
+      "Added overlay to cache for {}:v{} (cache size: {})", key.doc_uri,
+      key.doc_version, overlay_cache_.size());
+  return shared_session;
+}
+
+auto NewLanguageService::ClearCache() -> void {
+  logger_->debug("Clearing overlay cache ({} entries)", overlay_cache_.size());
+  overlay_cache_.clear();
 }
 
 }  // namespace slangd::services::new_service

--- a/src/slangd/services/new/overlay_session.cpp
+++ b/src/slangd/services/new/overlay_session.cpp
@@ -1,0 +1,160 @@
+#include "slangd/services/new/overlay_session.hpp"
+
+#include <slang/ast/Compilation.h>
+#include <slang/parsing/Preprocessor.h>
+#include <slang/syntax/SyntaxTree.h>
+#include <slang/util/Bag.h>
+
+#include "slangd/utils/canonical_path.hpp"
+
+namespace slangd::services::overlay {
+
+auto OverlaySession::Create(
+    std::string uri, std::string content,
+    std::shared_ptr<ProjectLayoutService> layout_service,
+    std::shared_ptr<const GlobalCatalog> catalog,
+    std::shared_ptr<spdlog::logger> logger) -> std::unique_ptr<OverlaySession> {
+  if (!logger) {
+    logger = spdlog::default_logger();
+  }
+
+  logger->debug("Creating overlay session for: {}", uri);
+
+  // Build fresh compilation with current buffer and optional catalog files
+  auto [source_manager, compilation] =
+      BuildCompilation(uri, content, layout_service, catalog, logger);
+
+  // Create symbol index with empty traverse_buffers (traverse all)
+  auto symbol_index = std::make_unique<semantic::SymbolIndex>(
+      semantic::SymbolIndex::FromCompilation(*compilation, {}, logger));
+
+  logger->debug(
+      "Overlay session created with {} definitions, {} references",
+      symbol_index->GetDefinitionRanges().size(),
+      symbol_index->GetReferenceMap().size());
+
+  return std::unique_ptr<OverlaySession>(new OverlaySession(
+      std::move(source_manager), std::move(compilation),
+      std::move(symbol_index), logger));
+}
+
+OverlaySession::OverlaySession(
+    std::shared_ptr<slang::SourceManager> source_manager,
+    std::unique_ptr<slang::ast::Compilation> compilation,
+    std::unique_ptr<semantic::SymbolIndex> symbol_index,
+    std::shared_ptr<spdlog::logger> logger)
+    : source_manager_(std::move(source_manager)),
+      compilation_(std::move(compilation)),
+      symbol_index_(std::move(symbol_index)),
+      logger_(std::move(logger)) {
+}
+
+auto OverlaySession::BuildCompilation(
+    std::string uri, std::string content,
+    std::shared_ptr<ProjectLayoutService> layout_service,
+    std::shared_ptr<const GlobalCatalog> catalog,
+    std::shared_ptr<spdlog::logger> logger)
+    -> std::tuple<
+        std::shared_ptr<slang::SourceManager>,
+        std::unique_ptr<slang::ast::Compilation>> {
+  // Create fresh source manager
+  auto source_manager = std::make_shared<slang::SourceManager>();
+
+  // Prepare preprocessor options
+  slang::Bag options;
+  slang::parsing::PreprocessorOptions pp_options;
+
+  // Apply include directories and defines from layout service
+  if (layout_service) {
+    for (const auto& include_dir : layout_service->GetIncludeDirectories()) {
+      pp_options.additionalIncludePaths.emplace_back(include_dir.Path());
+    }
+
+    for (const auto& define : layout_service->GetDefines()) {
+      pp_options.predefines.push_back(define);
+    }
+
+    logger->debug(
+        "Applied {} include dirs, {} defines",
+        layout_service->GetIncludeDirectories().size(),
+        layout_service->GetDefines().size());
+  }
+  options.set(pp_options);
+
+  // Create compilation options for LSP mode
+  slang::ast::CompilationOptions comp_options;
+  comp_options.flags |= slang::ast::CompilationFlags::LintMode;
+  comp_options.flags |= slang::ast::CompilationFlags::LanguageServerMode;
+  options.set(comp_options);
+
+  // Create compilation with options
+  auto compilation = std::make_unique<slang::ast::Compilation>(options);
+
+  // Add current buffer content (authoritative)
+  auto file_path = CanonicalPath::FromUri(uri);
+  auto buffer = source_manager->assignText(file_path.String(), content);
+  auto buffer_tree =
+      slang::syntax::SyntaxTree::fromBuffer(buffer, *source_manager, options);
+
+  if (buffer_tree) {
+    compilation->addSyntaxTree(buffer_tree);
+    logger->debug("Added current buffer: {}", file_path.Path().string());
+  } else {
+    logger->error(
+        "Failed to create syntax tree for buffer: {}",
+        file_path.Path().string());
+  }
+
+  // Add files from global catalog if available
+  if (catalog) {
+    // Add packages from catalog
+    for (const auto& package_info : catalog->GetPackages()) {
+      // Skip if this is the same file as our buffer (deduplication)
+      if (package_info.file_path.Path() == file_path.Path()) {
+        logger->debug(
+            "Skipping buffer file from catalog: {}",
+            package_info.file_path.Path().string());
+        continue;
+      }
+
+      auto package_tree_result = slang::syntax::SyntaxTree::fromFile(
+          package_info.file_path.Path().string(), *source_manager, options);
+      if (package_tree_result) {
+        compilation->addSyntaxTree(package_tree_result.value());
+        logger->debug(
+            "Added package from catalog: {}",
+            package_info.file_path.Path().string());
+      }
+    }
+
+    // Add interfaces from catalog
+    for (const auto& interface_info : catalog->GetInterfaces()) {
+      // Skip if this is the same file as our buffer (deduplication)
+      if (interface_info.file_path.Path() == file_path.Path()) {
+        logger->debug(
+            "Skipping buffer file from catalog: {}",
+            interface_info.file_path.Path().string());
+        continue;
+      }
+
+      auto interface_tree_result = slang::syntax::SyntaxTree::fromFile(
+          interface_info.file_path.Path().string(), *source_manager, options);
+      if (interface_tree_result) {
+        compilation->addSyntaxTree(interface_tree_result.value());
+        logger->debug(
+            "Added interface from catalog: {}",
+            interface_info.file_path.Path().string());
+      }
+    }
+
+    logger->debug(
+        "Added {} packages, {} interfaces from catalog",
+        catalog->GetPackages().size(), catalog->GetInterfaces().size());
+  } else {
+    logger->debug("No catalog provided - single-file mode");
+  }
+
+  return std::make_tuple(std::move(source_manager), std::move(compilation));
+}
+
+}  // namespace slangd::services::overlay

--- a/src/slangd/services/new/overlay_session.cpp
+++ b/src/slangd/services/new/overlay_session.cpp
@@ -13,7 +13,7 @@ auto OverlaySession::Create(
     std::string uri, std::string content,
     std::shared_ptr<ProjectLayoutService> layout_service,
     std::shared_ptr<const GlobalCatalog> catalog,
-    std::shared_ptr<spdlog::logger> logger) -> std::unique_ptr<OverlaySession> {
+    std::shared_ptr<spdlog::logger> logger) -> std::shared_ptr<OverlaySession> {
   if (!logger) {
     logger = spdlog::default_logger();
   }
@@ -44,7 +44,7 @@ auto OverlaySession::Create(
       definition_index->GetReferenceMap().size(),
       diagnostic_index->GetDiagnostics().size());
 
-  return std::unique_ptr<OverlaySession>(new OverlaySession(
+  return std::shared_ptr<OverlaySession>(new OverlaySession(
       std::move(source_manager), std::move(compilation),
       std::move(definition_index), std::move(diagnostic_index),
       std::move(symbol_index), logger));

--- a/src/slangd/utils/conversion.cpp
+++ b/src/slangd/utils/conversion.cpp
@@ -4,13 +4,13 @@ namespace slangd {
 
 auto ConvertSlangLocationToLspRange(
     const slang::SourceLocation& location,
-    const std::shared_ptr<slang::SourceManager>& source_manager) -> lsp::Range {
+    const slang::SourceManager& source_manager) -> lsp::Range {
   if (!location) {
     return lsp::Range{};
   }
 
-  auto line = source_manager->getLineNumber(location);
-  auto column = source_manager->getColumnNumber(location);
+  auto line = source_manager.getLineNumber(location);
+  auto column = source_manager.getColumnNumber(location);
 
   // Convert to single-point LSP position (0-based)
   auto position = lsp::Position{
@@ -22,22 +22,22 @@ auto ConvertSlangLocationToLspRange(
 }
 
 auto ConvertSlangRangeToLspRange(
-    const slang::SourceRange& range,
-    const std::shared_ptr<slang::SourceManager>& source_manager) -> lsp::Range {
+    const slang::SourceRange& range, const slang::SourceManager& source_manager)
+    -> lsp::Range {
   if (!range.start() || !range.end()) {
     return lsp::Range{};
   }
 
   // Convert start position
-  auto start_line = source_manager->getLineNumber(range.start());
-  auto start_column = source_manager->getColumnNumber(range.start());
+  auto start_line = source_manager.getLineNumber(range.start());
+  auto start_column = source_manager.getColumnNumber(range.start());
   lsp::Position start_pos{
       .line = static_cast<int>(start_line - 1),
       .character = static_cast<int>(start_column - 1)};
 
   // Convert end position
-  auto end_line = source_manager->getLineNumber(range.end());
-  auto end_column = source_manager->getColumnNumber(range.end());
+  auto end_line = source_manager.getLineNumber(range.end());
+  auto end_column = source_manager.getColumnNumber(range.end());
   lsp::Position end_pos{
       .line = static_cast<int>(end_line - 1),
       .character = static_cast<int>(end_column - 1)};
@@ -47,14 +47,9 @@ auto ConvertSlangRangeToLspRange(
 
 auto ConvertLspPositionToSlangLocation(
     const lsp::Position& position, const slang::BufferID& buffer_id,
-    const std::shared_ptr<slang::SourceManager>& source_manager)
-    -> slang::SourceLocation {
-  if (!source_manager) {
-    return {};
-  }
-
+    const slang::SourceManager& source_manager) -> slang::SourceLocation {
   // Get the text content for this buffer
-  std::string_view text = source_manager->getSourceText(buffer_id);
+  std::string_view text = source_manager.getSourceText(buffer_id);
   if (text.empty()) {
     return {};
   }
@@ -100,14 +95,13 @@ auto ConvertLspPositionToSlangLocation(
 
 auto ConvertSlangLocationToLspLocation(
     const slang::SourceLocation& location,
-    const std::shared_ptr<slang::SourceManager>& source_manager)
-    -> lsp::Location {
-  if (!location || !source_manager) {
+    const slang::SourceManager& source_manager) -> lsp::Location {
+  if (!location) {
     return lsp::Location{};
   }
 
   // Get the file name from the buffer
-  auto file_name = source_manager->getFileName(location);
+  auto file_name = source_manager.getFileName(location);
 
   // Create a range at this position
   auto range = ConvertSlangLocationToLspRange(location, source_manager);
@@ -118,16 +112,15 @@ auto ConvertSlangLocationToLspLocation(
 
 auto ConvertSlangLocationToLspPosition(
     const slang::SourceLocation& location,
-    const std::shared_ptr<slang::SourceManager>& source_manager)
-    -> lsp::Position {
-  if (!location || !source_manager) {
+    const slang::SourceManager& source_manager) -> lsp::Position {
+  if (!location) {
     return {};
   }
 
   // Extract line and column information from Slang source location
   // Note: Slang line/column are 1-based but LSP expects 0-based positions
-  auto line = source_manager->getLineNumber(location);
-  auto column = source_manager->getColumnNumber(location);
+  auto line = source_manager.getLineNumber(location);
+  auto column = source_manager.getColumnNumber(location);
 
   // Convert to LSP position (0-based line and column)
   return lsp::Position{

--- a/src/slangd/utils/path_utils.cpp
+++ b/src/slangd/utils/path_utils.cpp
@@ -100,15 +100,14 @@ auto NormalizePath(std::filesystem::path path) -> std::filesystem::path {
 
 auto IsLocationInDocument(
     const slang::SourceLocation& location,
-    const std::shared_ptr<slang::SourceManager>& source_manager,
-    std::string_view uri) -> bool {
-  if (!location || !source_manager) {
+    const slang::SourceManager& source_manager, std::string_view uri) -> bool {
+  if (!location) {
     return false;
   }
 
   std::string document_path = UriToPath(uri);
   std::filesystem::path location_path =
-      source_manager->getFullPath(location.buffer());
+      source_manager.getFullPath(location.buffer());
 
   return NormalizePath(document_path) == NormalizePath(location_path);
 }

--- a/test/slangd/BUILD.bazel
+++ b/test/slangd/BUILD.bazel
@@ -102,3 +102,16 @@ cc_test(
         "@slang",
     ],
 )
+
+cc_test(
+    name = "overlay_session_test",
+    timeout = "short",
+    srcs = [
+        "services/new/overlay_session_test.cpp",
+    ],
+    deps = [
+        "//:slangd_core",
+        "@catch2",
+        "@slang",
+    ],
+)

--- a/test/slangd/BUILD.bazel
+++ b/test/slangd/BUILD.bazel
@@ -39,10 +39,10 @@ cc_test(
 )
 
 cc_test(
-    name = "symbol_index_test",
+    name = "definition_index_test",
     timeout = "short",
     srcs = [
-        "semantic/symbol_index_test.cpp",
+        "semantic/definition_index_test.cpp",
     ],
     deps = [
         "//:slangd_core",
@@ -108,6 +108,19 @@ cc_test(
     timeout = "short",
     srcs = [
         "services/new/overlay_session_test.cpp",
+    ],
+    deps = [
+        "//:slangd_core",
+        "@catch2",
+        "@slang",
+    ],
+)
+
+cc_test(
+    name = "symbol_index_test",
+    timeout = "short",
+    srcs = [
+        "semantic/symbol_index_test.cpp",
     ],
     deps = [
         "//:slangd_core",

--- a/test/slangd/semantic/definition_index_test.cpp
+++ b/test/slangd/semantic/definition_index_test.cpp
@@ -1,0 +1,230 @@
+#include "slangd/semantic/definition_index.hpp"
+
+#include <memory>
+#include <string>
+
+#include <catch2/catch_all.hpp>
+#include <spdlog/spdlog.h>
+
+#include "slang/ast/Compilation.h"
+#include "slang/syntax/SyntaxTree.h"
+#include "slang/text/SourceManager.h"
+
+auto main(int argc, char* argv[]) -> int {
+  spdlog::set_level(spdlog::level::debug);
+  spdlog::set_pattern("[%l] %v");
+  return Catch::Session().run(argc, argv);
+}
+
+class DefinitionIndexFixture {
+  using DefinitionIndex = slangd::semantic::DefinitionIndex;
+  using SymbolKey = slangd::semantic::SymbolKey;
+
+ public:
+  auto BuildIndexFromSource(const std::string& source) -> DefinitionIndex {
+    std::string path = "test.sv";
+    sourceManager_ = std::make_unique<slang::SourceManager>();
+    auto buffer = sourceManager_->assignText(path, source);
+    buffer_id_ = buffer.id;
+    auto tree = slang::syntax::SyntaxTree::fromBuffer(buffer, *sourceManager_);
+
+    compilation_ = std::make_unique<slang::ast::Compilation>();
+    compilation_->addSyntaxTree(tree);
+
+    return DefinitionIndex::FromCompilation(*compilation_, {buffer_id_});
+  }
+
+  auto MakeKey(const std::string& source, const std::string& symbol)
+      -> SymbolKey {
+    size_t offset = source.find(symbol);
+    return SymbolKey{.bufferId = buffer_id_.getId(), .offset = offset};
+  }
+
+  auto MakeRange(
+      const std::string& source, const std::string& search_string,
+      size_t symbol_size) -> slang::SourceRange {
+    size_t offset = source.find(search_string);
+    auto start = slang::SourceLocation{buffer_id_, offset};
+    auto end = slang::SourceLocation{buffer_id_, offset + symbol_size};
+    return slang::SourceRange{start, end};
+  }
+
+  [[nodiscard]] auto GetBufferId() const -> uint32_t {
+    return buffer_id_.getId();
+  }
+  [[nodiscard]] auto GetSourceManager() const -> slang::SourceManager* {
+    return sourceManager_.get();
+  }
+
+ private:
+  std::unique_ptr<slang::SourceManager> sourceManager_;
+  std::unique_ptr<slang::ast::Compilation> compilation_;
+  slang::BufferID buffer_id_;
+};
+
+TEST_CASE("DefinitionIndex definition tracking", "[symbol_index]") {
+  DefinitionIndexFixture fixture;
+
+  SECTION("basic logic declaration") {
+    const std::string source = R"(
+      module m;
+        logic test_signal;
+      endmodule
+    )";
+
+    auto index = fixture.BuildIndexFromSource(source);
+    REQUIRE(!index.GetDefinitionRanges().empty());
+    REQUIRE(index.GetDefinitionRanges().contains(
+        fixture.MakeKey(source, "test_signal")));
+  }
+
+  SECTION("nested scope indexing") {
+    const std::string source = R"(
+      module m;
+        if (1) begin
+          logic nested_signal;
+        end
+      endmodule
+    )";
+
+    auto index = fixture.BuildIndexFromSource(source);
+    REQUIRE(!index.GetDefinitionRanges().empty());
+    REQUIRE(index.GetDefinitionRanges().contains(
+        fixture.MakeKey(source, "nested_signal")));
+  }
+
+  SECTION("multiple symbols indexing") {
+    const std::string source = R"(
+      module m;
+        logic test_signal_1, test_signal_2, test_signal_3;
+      endmodule
+    )";
+
+    auto index = fixture.BuildIndexFromSource(source);
+    REQUIRE(!index.GetDefinitionRanges().empty());
+
+    for (const std::string& name :
+         {"test_signal_1", "test_signal_2", "test_signal_3"}) {
+      REQUIRE(
+          index.GetDefinitionRanges().contains(fixture.MakeKey(source, name)));
+    }
+  }
+}
+
+TEST_CASE("DefinitionIndex reference tracking", "[symbol_index]") {
+  DefinitionIndexFixture fixture;
+
+  const std::string source = R"(
+    module m;
+      logic test_signal;
+
+      initial begin
+        test_signal = 1; // Reference to test_signal
+      end
+    endmodule
+  )";
+
+  auto index = fixture.BuildIndexFromSource(source);
+  auto ref_map = index.GetReferenceMap();
+  auto def_key = fixture.MakeKey(source, "test_signal");
+  auto ref_range = fixture.MakeRange(
+      source, "test_signal = 1", std::string("test_signal").size());
+  REQUIRE(ref_map.contains(ref_range));
+  REQUIRE(ref_map.at(ref_range) == def_key);
+}
+
+TEST_CASE(
+    "DefinitionIndex handles interface ports without crash", "[symbol_index]") {
+  DefinitionIndexFixture fixture;
+
+  SECTION("basic interface port with member access") {
+    const std::string source = R"(
+      interface cpu_if;
+        logic [31:0] addr;
+        logic [31:0] data;
+      endinterface
+
+      module cpu_core(cpu_if.master bus);
+        assign bus.addr = 32'h1000;
+        assign bus.data = 32'hDEAD;
+        logic internal_var;
+      endmodule
+    )";
+
+    // Primary goal: This should not crash during symbol indexing
+    auto index = fixture.BuildIndexFromSource(source);
+
+    // Secondary goal: Basic sanity check that indexing still works
+    REQUIRE(!index.GetDefinitionRanges().empty());
+
+    // Just verify that SOME symbols are indexed (crash prevention is the main
+    // goal) Interface definitions may not be indexed the same way as variables
+    REQUIRE(index.GetDefinitionRanges().contains(
+        fixture.MakeKey(source, "internal_var")));
+  }
+
+  SECTION("undefined interface - single file resilience") {
+    const std::string source = R"(
+      // No interface definition - testing LSP resilience
+      module processor(undefined_if bus);
+        assign bus.signal = 1'b1;    // Interface doesn't exist
+        assign bus.data = 32'hDEAD;  // Member doesn't exist
+
+        // Regular symbols should still be indexed
+        logic internal_state;
+        logic [7:0] counter;
+      endmodule
+    )";
+
+    // Primary: Should not crash even with undefined interface
+    auto index = fixture.BuildIndexFromSource(source);
+
+    // Secondary: Regular symbols still indexed despite interface errors
+    REQUIRE(!index.GetDefinitionRanges().empty());
+    REQUIRE(index.GetDefinitionRanges().contains(
+        fixture.MakeKey(source, "internal_state")));
+    REQUIRE(index.GetDefinitionRanges().contains(
+        fixture.MakeKey(source, "counter")));
+
+    // The undefined interface references (bus.signal, bus.data) are gracefully
+    // handled
+  }
+
+  SECTION("interface in always_comb conditions and RHS") {
+    const std::string source = R"(
+      // Pattern that triggers Expression::tryBindInterfaceRef in procedural blocks
+      module generic_module(generic_if iface);
+        logic state;
+        logic [7:0] counter;
+        logic enable;
+
+        always_comb begin
+          if (enable & ~iface.ready) begin      // Interface in condition
+            state = 1'b0;
+          end else if (enable & iface.ready) begin
+            if (iface.mode == 1'b1) begin      // Interface in comparison
+              state = 1'b1;
+            end else begin
+              counter = iface.data;            // Interface in RHS assignment
+            end
+          end
+        end
+      endmodule
+    )";
+
+    // Primary: Should not crash with interface expressions in always_comb
+    auto index = fixture.BuildIndexFromSource(source);
+
+    // Secondary: Regular symbols still indexed despite interface usage
+    REQUIRE(!index.GetDefinitionRanges().empty());
+    REQUIRE(
+        index.GetDefinitionRanges().contains(fixture.MakeKey(source, "state")));
+    REQUIRE(index.GetDefinitionRanges().contains(
+        fixture.MakeKey(source, "counter")));
+    REQUIRE(index.GetDefinitionRanges().contains(
+        fixture.MakeKey(source, "enable")));
+
+    // This test targets Expression::tryBindInterfaceRef code path
+    // that differs from simple continuous assignments
+  }
+}

--- a/test/slangd/semantic/symbol_index_test.cpp
+++ b/test/slangd/semantic/symbol_index_test.cpp
@@ -4,227 +4,79 @@
 #include <string>
 
 #include <catch2/catch_all.hpp>
-#include <spdlog/spdlog.h>
-
-#include "slang/ast/Compilation.h"
-#include "slang/syntax/SyntaxTree.h"
-#include "slang/text/SourceManager.h"
+#include <slang/ast/Compilation.h>
+#include <slang/syntax/SyntaxTree.h>
+#include <slang/text/SourceManager.h>
+#include <slang/util/Bag.h>
 
 auto main(int argc, char* argv[]) -> int {
-  spdlog::set_level(spdlog::level::debug);
-  spdlog::set_pattern("[%l] %v");
   return Catch::Session().run(argc, argv);
 }
 
-class SymbolIndexFixture {
-  using SymbolIndex = slangd::semantic::SymbolIndex;
-  using SymbolKey = slangd::semantic::SymbolKey;
+namespace slangd::semantic {
 
- public:
-  auto BuildIndexFromSource(const std::string& source) -> SymbolIndex {
-    std::string path = "test.sv";
-    sourceManager_ = std::make_unique<slang::SourceManager>();
-    auto buffer = sourceManager_->assignText(path, source);
-    buffer_id_ = buffer.id;
-    auto tree = slang::syntax::SyntaxTree::fromBuffer(buffer, *sourceManager_);
+// Helper function to extract symbols from string (similar to legacy test)
+auto ExtractSymbolsFromString(const std::string& source)
+    -> std::vector<lsp::DocumentSymbol> {
+  // Create source manager and compilation
+  auto source_manager = std::make_shared<slang::SourceManager>();
+  slang::Bag options;
+  auto compilation = std::make_unique<slang::ast::Compilation>(options);
 
-    compilation_ = std::make_unique<slang::ast::Compilation>();
-    compilation_->addSyntaxTree(tree);
-
-    return SymbolIndex::FromCompilation(*compilation_, {buffer_id_});
+  // Add source
+  auto buffer = source_manager->assignText("test.sv", source);
+  auto tree = slang::syntax::SyntaxTree::fromBuffer(buffer, *source_manager);
+  if (tree) {
+    compilation->addSyntaxTree(tree);
   }
 
-  auto MakeKey(const std::string& source, const std::string& symbol)
-      -> SymbolKey {
-    size_t offset = source.find(symbol);
-    return SymbolKey{.bufferId = buffer_id_.getId(), .offset = offset};
-  }
-
-  auto MakeRange(
-      const std::string& source, const std::string& search_string,
-      size_t symbol_size) -> slang::SourceRange {
-    size_t offset = source.find(search_string);
-    auto start = slang::SourceLocation{buffer_id_, offset};
-    auto end = slang::SourceLocation{buffer_id_, offset + symbol_size};
-    return slang::SourceRange{start, end};
-  }
-
-  [[nodiscard]] auto GetBufferId() const -> uint32_t {
-    return buffer_id_.getId();
-  }
-  [[nodiscard]] auto GetSourceManager() const -> slang::SourceManager* {
-    return sourceManager_.get();
-  }
-
- private:
-  std::unique_ptr<slang::SourceManager> sourceManager_;
-  std::unique_ptr<slang::ast::Compilation> compilation_;
-  slang::BufferID buffer_id_;
-};
-
-TEST_CASE("SymbolIndex definition tracking", "[symbol_index]") {
-  SymbolIndexFixture fixture;
-
-  SECTION("basic logic declaration") {
-    const std::string source = R"(
-      module m;
-        logic test_signal;
-      endmodule
-    )";
-
-    auto index = fixture.BuildIndexFromSource(source);
-    REQUIRE(!index.GetDefinitionRanges().empty());
-    REQUIRE(index.GetDefinitionRanges().contains(
-        fixture.MakeKey(source, "test_signal")));
-  }
-
-  SECTION("nested scope indexing") {
-    const std::string source = R"(
-      module m;
-        if (1) begin
-          logic nested_signal;
-        end
-      endmodule
-    )";
-
-    auto index = fixture.BuildIndexFromSource(source);
-    REQUIRE(!index.GetDefinitionRanges().empty());
-    REQUIRE(index.GetDefinitionRanges().contains(
-        fixture.MakeKey(source, "nested_signal")));
-  }
-
-  SECTION("multiple symbols indexing") {
-    const std::string source = R"(
-      module m;
-        logic test_signal_1, test_signal_2, test_signal_3;
-      endmodule
-    )";
-
-    auto index = fixture.BuildIndexFromSource(source);
-    REQUIRE(!index.GetDefinitionRanges().empty());
-
-    for (const std::string& name :
-         {"test_signal_1", "test_signal_2", "test_signal_3"}) {
-      REQUIRE(
-          index.GetDefinitionRanges().contains(fixture.MakeKey(source, name)));
-    }
-  }
+  // Create symbol index and extract symbols
+  auto index = SymbolIndex::FromCompilation(*compilation, *source_manager);
+  return index->GetDocumentSymbols("test.sv");
 }
 
-TEST_CASE("SymbolIndex reference tracking", "[symbol_index]") {
-  SymbolIndexFixture fixture;
-
-  const std::string source = R"(
-    module m;
-      logic test_signal;
-
-      initial begin
-        test_signal = 1; // Reference to test_signal
-      end
+TEST_CASE("SymbolIndex extracts basic module", "[symbol_index]") {
+  std::string module_code = R"(
+    module test_module;
     endmodule
   )";
 
-  auto index = fixture.BuildIndexFromSource(source);
-  auto ref_map = index.GetReferenceMap();
-  auto def_key = fixture.MakeKey(source, "test_signal");
-  auto ref_range = fixture.MakeRange(
-      source, "test_signal = 1", std::string("test_signal").size());
-  REQUIRE(ref_map.contains(ref_range));
-  REQUIRE(ref_map.at(ref_range) == def_key);
+  auto symbols = ExtractSymbolsFromString(module_code);
+
+  REQUIRE(symbols.size() == 1);
+  REQUIRE(symbols[0].name == "test_module");
+  REQUIRE(symbols[0].kind == lsp::SymbolKind::kClass);
 }
 
-TEST_CASE(
-    "SymbolIndex handles interface ports without crash", "[symbol_index]") {
-  SymbolIndexFixture fixture;
+TEST_CASE("SymbolIndex extracts basic package", "[symbol_index]") {
+  std::string package_code = R"(
+    package test_pkg;
+    endpackage
+  )";
 
-  SECTION("basic interface port with member access") {
-    const std::string source = R"(
-      interface cpu_if;
-        logic [31:0] addr;
-        logic [31:0] data;
-      endinterface
+  auto symbols = ExtractSymbolsFromString(package_code);
 
-      module cpu_core(cpu_if.master bus);
-        assign bus.addr = 32'h1000;
-        assign bus.data = 32'hDEAD;
-        logic internal_var;
-      endmodule
-    )";
-
-    // Primary goal: This should not crash during symbol indexing
-    auto index = fixture.BuildIndexFromSource(source);
-
-    // Secondary goal: Basic sanity check that indexing still works
-    REQUIRE(!index.GetDefinitionRanges().empty());
-
-    // Just verify that SOME symbols are indexed (crash prevention is the main
-    // goal) Interface definitions may not be indexed the same way as variables
-    REQUIRE(index.GetDefinitionRanges().contains(
-        fixture.MakeKey(source, "internal_var")));
-  }
-
-  SECTION("undefined interface - single file resilience") {
-    const std::string source = R"(
-      // No interface definition - testing LSP resilience
-      module processor(undefined_if bus);
-        assign bus.signal = 1'b1;    // Interface doesn't exist
-        assign bus.data = 32'hDEAD;  // Member doesn't exist
-
-        // Regular symbols should still be indexed
-        logic internal_state;
-        logic [7:0] counter;
-      endmodule
-    )";
-
-    // Primary: Should not crash even with undefined interface
-    auto index = fixture.BuildIndexFromSource(source);
-
-    // Secondary: Regular symbols still indexed despite interface errors
-    REQUIRE(!index.GetDefinitionRanges().empty());
-    REQUIRE(index.GetDefinitionRanges().contains(
-        fixture.MakeKey(source, "internal_state")));
-    REQUIRE(index.GetDefinitionRanges().contains(
-        fixture.MakeKey(source, "counter")));
-
-    // The undefined interface references (bus.signal, bus.data) are gracefully
-    // handled
-  }
-
-  SECTION("interface in always_comb conditions and RHS") {
-    const std::string source = R"(
-      // Pattern that triggers Expression::tryBindInterfaceRef in procedural blocks
-      module generic_module(generic_if iface);
-        logic state;
-        logic [7:0] counter;
-        logic enable;
-
-        always_comb begin
-          if (enable & ~iface.ready) begin      // Interface in condition
-            state = 1'b0;
-          end else if (enable & iface.ready) begin
-            if (iface.mode == 1'b1) begin      // Interface in comparison
-              state = 1'b1;
-            end else begin
-              counter = iface.data;            // Interface in RHS assignment
-            end
-          end
-        end
-      endmodule
-    )";
-
-    // Primary: Should not crash with interface expressions in always_comb
-    auto index = fixture.BuildIndexFromSource(source);
-
-    // Secondary: Regular symbols still indexed despite interface usage
-    REQUIRE(!index.GetDefinitionRanges().empty());
-    REQUIRE(
-        index.GetDefinitionRanges().contains(fixture.MakeKey(source, "state")));
-    REQUIRE(index.GetDefinitionRanges().contains(
-        fixture.MakeKey(source, "counter")));
-    REQUIRE(index.GetDefinitionRanges().contains(
-        fixture.MakeKey(source, "enable")));
-
-    // This test targets Expression::tryBindInterfaceRef code path
-    // that differs from simple continuous assignments
-  }
+  REQUIRE(symbols.size() == 1);
+  REQUIRE(symbols[0].name == "test_pkg");
+  REQUIRE(symbols[0].kind == lsp::SymbolKind::kPackage);
 }
+
+TEST_CASE("SymbolIndex extracts multiple top-level symbols", "[symbol_index]") {
+  std::string multi_code = R"(
+    module module1; endmodule
+    module module2; endmodule
+    package package1; endpackage
+  )";
+
+  auto symbols = ExtractSymbolsFromString(multi_code);
+
+  REQUIRE(symbols.size() == 3);
+  REQUIRE(symbols[0].name == "module1");
+  REQUIRE(symbols[0].kind == lsp::SymbolKind::kClass);
+  REQUIRE(symbols[1].name == "module2");
+  REQUIRE(symbols[1].kind == lsp::SymbolKind::kClass);
+  REQUIRE(symbols[2].name == "package1");
+  REQUIRE(symbols[2].kind == lsp::SymbolKind::kPackage);
+}
+
+}  // namespace slangd::semantic

--- a/test/slangd/services/new/overlay_session_test.cpp
+++ b/test/slangd/services/new/overlay_session_test.cpp
@@ -72,14 +72,14 @@ TEST_CASE(
     REQUIRE(session != nullptr);
 
     // Verify session has valid components
-    const auto& symbol_index = session->GetSymbolIndex();
+    const auto& definition_index = session->GetDefinitionIndex();
 
     // Basic validation - session should be functional
     // No need to check low-level Slang diagnostics here - that's tested
     // elsewhere
 
     // Should have some definitions in the symbol index
-    const auto& definitions = symbol_index.GetDefinitionRanges();
+    const auto& definitions = definition_index.GetDefinitionRanges();
     REQUIRE(definitions.size() > 0);
 
     spdlog::info(
@@ -113,8 +113,8 @@ TEST_CASE("OverlaySession works without GlobalCatalog", "[overlay_session]") {
     REQUIRE(session != nullptr);
 
     // Should work fine in single-file mode
-    const auto& symbol_index = session->GetSymbolIndex();
-    const auto& definitions = symbol_index.GetDefinitionRanges();
+    const auto& definition_index = session->GetDefinitionIndex();
+    const auto& definitions = definition_index.GetDefinitionRanges();
 
     spdlog::info(
         "Single-file overlay session: {} definitions", definitions.size());

--- a/test/slangd/services/new/overlay_session_test.cpp
+++ b/test/slangd/services/new/overlay_session_test.cpp
@@ -1,0 +1,155 @@
+#include "slangd/services/new/overlay_session.hpp"
+
+#include <string>
+
+#include <asio.hpp>
+#include <catch2/catch_all.hpp>
+#include <spdlog/spdlog.h>
+
+#include "slangd/core/project_layout_service.hpp"
+#include "slangd/utils/canonical_path.hpp"
+
+auto main(int argc, char* argv[]) -> int {
+  spdlog::set_level(spdlog::level::debug);
+  spdlog::set_pattern("[%l] %v");
+  return Catch::Session().run(argc, argv);
+}
+
+// Helper to run async test functions with coroutines
+template <typename F>
+void RunTest(F&& test_fn) {
+  asio::io_context io_context;
+  auto executor = io_context.get_executor();
+
+  bool completed = false;
+  std::exception_ptr exception;
+
+  asio::co_spawn(
+      io_context,
+      [fn = std::forward<F>(test_fn), &completed, &exception,
+       executor]() -> asio::awaitable<void> {
+        try {
+          co_await fn(executor);
+          completed = true;
+        } catch (...) {
+          exception = std::current_exception();
+          completed = true;
+        }
+      },
+      asio::detached);
+
+  io_context.run();
+
+  if (exception) {
+    std::rethrow_exception(exception);
+  }
+
+  REQUIRE(completed);
+}
+
+TEST_CASE(
+    "OverlaySession can be created with simple module", "[overlay_session]") {
+  RunTest([](asio::any_io_executor executor) -> asio::awaitable<void> {
+    // Setup test workspace
+    auto workspace_root = slangd::CanonicalPath::CurrentPath();
+    auto layout_service = slangd::ProjectLayoutService::Create(
+        executor, workspace_root, spdlog::default_logger());
+
+    // Simple SystemVerilog module
+    std::string test_content = R"(
+      module test_module;
+        wire x;
+        wire y;
+      endmodule
+    )";
+
+    const std::string uri = "file:///test.sv";
+
+    // Create overlay session
+    auto session = slangd::services::overlay::OverlaySession::Create(
+        uri, test_content, layout_service);
+
+    REQUIRE(session != nullptr);
+
+    // Verify session has valid components
+    const auto& symbol_index = session->GetSymbolIndex();
+
+    // Basic validation - session should be functional
+    // No need to check low-level Slang diagnostics here - that's tested
+    // elsewhere
+
+    // Should have some definitions in the symbol index
+    const auto& definitions = symbol_index.GetDefinitionRanges();
+    REQUIRE(definitions.size() > 0);
+
+    spdlog::info(
+        "OverlaySession created successfully with {} definitions",
+        definitions.size());
+
+    co_return;
+  });
+}
+
+TEST_CASE("OverlaySession works without GlobalCatalog", "[overlay_session]") {
+  RunTest([](asio::any_io_executor executor) -> asio::awaitable<void> {
+    auto workspace_root = slangd::CanonicalPath::CurrentPath();
+    auto layout_service = slangd::ProjectLayoutService::Create(
+        executor, workspace_root, spdlog::default_logger());
+
+    std::string test_content = R"(
+      module simple_module;
+        parameter WIDTH = 8;
+        input logic [WIDTH-1:0] data_in;
+        output logic [WIDTH-1:0] data_out;
+      endmodule
+    )";
+
+    const std::string uri = "file:///simple.sv";
+
+    // Create session with explicit nullptr catalog (single-file mode)
+    auto session = slangd::services::overlay::OverlaySession::Create(
+        uri, test_content, layout_service, nullptr);
+
+    REQUIRE(session != nullptr);
+
+    // Should work fine in single-file mode
+    const auto& symbol_index = session->GetSymbolIndex();
+    const auto& definitions = symbol_index.GetDefinitionRanges();
+
+    spdlog::info(
+        "Single-file overlay session: {} definitions", definitions.size());
+
+    co_return;
+  });
+}
+
+TEST_CASE(
+    "OverlaySession handles syntax errors gracefully", "[overlay_session]") {
+  RunTest([](asio::any_io_executor executor) -> asio::awaitable<void> {
+    auto workspace_root = slangd::CanonicalPath::CurrentPath();
+    auto layout_service = slangd::ProjectLayoutService::Create(
+        executor, workspace_root, spdlog::default_logger());
+
+    // Invalid SystemVerilog with syntax error
+    std::string invalid_content = R"(
+      module broken_module
+        wire x    // missing semicolon
+      endmodule   // missing semicolon after module declaration
+    )";
+
+    const std::string uri = "file:///broken.sv";
+
+    // Should create session even with syntax errors
+    auto session = slangd::services::overlay::OverlaySession::Create(
+        uri, invalid_content, layout_service);
+
+    REQUIRE(session != nullptr);
+
+    // Session should be created even with syntax errors
+    // Actual diagnostic validation is handled by ConvertSlangDiagnosticsToLsp
+
+    spdlog::info("OverlaySession handled syntax errors correctly");
+
+    co_return;
+  });
+}


### PR DESCRIPTION
## Summary

Complete architectural foundation implementing overlay session infrastructure with performance optimizations:

- Fix facade interface patterns and remove dynamic_pointer_cast violations
- Add NewLanguageService with overlay sessions for per-request compilation  
- Create specialized indexes (DiagnosticIndex, DefinitionIndex, SymbolIndex)
- Implement LRU caching for overlay session reuse with 3x performance improvement

## Changes

**Interface and Facade Fixes**
- Add `InitializeWorkspace()` to `LanguageServiceBase` interface
- Remove `dynamic_pointer_cast` violations from SlangdLspServer
- Restore proper facade pattern integrity

**New Architecture Implementation**
- Create `NewLanguageService` as clean alternative to legacy implementation
- Design `OverlaySession` class for per-request compilation + indexing
- Add forward-thinking `GlobalCatalog` interface for future integration

**Specialized Index Architecture**
- Create `DiagnosticIndex` to mirror existing symbol indexing patterns
- Rename `SymbolIndex` → `DefinitionIndex` for definition lookups
- Create new `SymbolIndex` focused on document symbols
- Achieve consistent delegation pattern for all LSP methods

**Performance Optimization via Caching**
- Add version parameters to interface methods for cache key generation
- Implement LRU cache with 8-entry limit using (uri, version, catalog_version) keys
- Update `OverlaySession` factory to return `shared_ptr` for cache sharing
- Add automatic cache invalidation on configuration changes

## Test Plan

- All existing tests pass (10/10 slangd tests)
- Build completes successfully with no compilation errors or warnings  
- Code formatted with clang-format
- Main executable builds and runs correctly