### PR TITLE
Add slash commands for standardized commit and PR workflows

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -2,12 +2,12 @@ Create a git commit following the project conventions
 
 ## Steps
 
-1. Format code: `find src include test -name "*.cpp" -o -name "*.hpp" | xargs clang-format -i`
-2. Build: `bazel build //...`
-3. Test: `bazel test //...`
-4. Check git status and diff. If we are on the main branch, stop and ask the user if they want to switch to a feature branch.
-5. Create commit following this format:
-   - Short summary + bullet points using `-`
-   - No Claude attribution
-   - Focus on what changed
-6. Commit messages: Short summary + 2–5 bullet points using `-` in details, no Claude attribution, focus on what changed, not process or steps
+1. Format, build, test: `find src include test -name "*.cpp" -o -name "*.hpp" | xargs clang-format -i && bazel build //... && bazel test //...`
+2. Check status and style: `git status`, `git diff`, `git log --oneline -5`, `git show HEAD --stat`
+3. If on main branch, stop and ask user to switch to feature branch
+4. Create commit matching scope:
+   - **Simple changes** (1 file, doc updates): 1-2 bullets
+   - **Medium changes** (few files, features): 2-3 bullets
+   - **Major changes** (refactors, systems): 3-5 bullets
+   - Short summary line, bullet points using `-`
+   - No Claude attribution, focus on what changed

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,0 +1,27 @@
+Create a GitHub pull request following project conventions
+
+## Steps
+
+1. Push branch: `git push` (or `git push -u origin <branch>` if new)
+2. Review commits: `git log origin/main..HEAD --format='%s%n%b%n---'`
+3. Check changes overview: `git diff origin/main...HEAD --stat`
+4. Create PR with structure:
+   - **Summary**: What this PR does (user-facing benefit)
+   - **Key Changes**: Group by major features (give each proportional space based on scope)
+   - **Documentation**: New/updated docs
+   - **Testing**: What was tested
+5. Important principles:
+   - Review commit messages to understand full scope - don't rely on memory
+   - Major features deserve detailed sections with subsections
+   - Emphasize breakthroughs and difficult problems solved
+   - Avoid redundant sections
+   - Focus on what changed and why, not internal process or philosophy
+
+## Example Structure
+
+For a PR with 15 commits spanning architecture refactor + new feature:
+
+- Give each major work area a detailed section
+- Use subsections to break down complex changes
+- Highlight achievements explicitly (e.g., "Breakthrough Feature")
+- Don't bury significant work under single bullets


### PR DESCRIPTION
## Summary

Adds two new slash commands to streamline development workflow with consistent conventions for commits and pull requests.

## Key Changes

- **`/pr` command**: Guides PR creation with structured templates emphasizing proportional detail based on change scope
- **`/commit` command improvements**: Consolidates format/build/test steps and adds scope-based commit message guidelines

## Documentation

- `.claude/commands/pr.md`: New command defining PR workflow steps and structure guidelines
- `.claude/commands/commit.md`: Enhanced with streamlined steps and proportionality guidance

## Testing

- Verified commands render correctly in Claude Code
- Applied both commands in this PR creation workflow