### PR TITLE
Add missing go-to-definition features

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -2,7 +2,7 @@ Create a GitHub pull request following project conventions
 
 ## Steps
 
-1. Push branch: `git push` (or `git push -u origin <branch>` if new)
+1. Push branch: `git push -u origin HEAD` (handles both new and existing branches)
 2. Review commits: `git log origin/main..HEAD --format='%s%n%b%n---'`
 3. Check changes overview: `git diff origin/main...HEAD --stat`
 4. Create PR with structure:
@@ -12,6 +12,7 @@ Create a GitHub pull request following project conventions
    - **Testing**: What was tested
 5. Important principles:
    - Review commit messages to understand full scope - don't rely on memory
+   - Organize by themes, not commit chronology - group related work into logical sections
    - Major features deserve detailed sections with subsections
    - Emphasize breakthroughs and difficult problems solved
    - Avoid redundant sections

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 **Adding new language features:**
 
 When adding support for new SystemVerilog constructs:
+
 1. Add tests first (TDD approach)
 2. Check `docs/SEMANTIC_INDEXING.md` for implementation patterns
 3. **Check existing Slang infrastructure** - look for `get*()`, `find()`, or resolution methods before building custom solutions
@@ -82,6 +83,7 @@ SystemVerilog LSP server with modular design:
 - Use modern C++23 standard library features (e.g., `std::ranges::contains`)
 - Use `toString(symbol.kind) -> std::string_view` for Slang enum printing
 - Use `slang::syntax::toString(syntax.kind) -> std::string_view` for SyntaxKind printing
+- Print source ranges: `range.start().offset()..range.end().offset()` for offsets, or use `source_manager.getLineNumber(range.start())` for line numbers
 
 **General Debugging:**
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,7 +16,7 @@ bazel_dep(name = "slang", version = "9.0.0")
 git_override(
     module_name = "slang",
     remote = "https://github.com/hankhsu1996/slang.git",
-    commit = "8c09a579",
+    commit = "f461a43b",
 )
 
 # local_path_override(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,7 +16,7 @@ bazel_dep(name = "slang", version = "9.0.0")
 git_override(
     module_name = "slang",
     remote = "https://github.com/hankhsu1996/slang.git",
-    commit = "2715c82c",
+    commit = "8c09a579",
 )
 
 # local_path_override(

--- a/docs/DESIGN_PRINCIPLES.md
+++ b/docs/DESIGN_PRINCIPLES.md
@@ -133,6 +133,18 @@ When someone says "no manual searching" or "no state tracking", these aren't arb
 - Stateless, declarative code
 - Simple, composable solutions
 
+### Prefer Positive Conditions
+
+Write conditions that express WHEN to do something, not when to skip.
+
+**Why this matters**:
+
+- Positive conditions document intent: "traverse when in standalone mode" vs "skip when nested"
+- Easier to verify correctness: check the main case is handled, not all exclusions
+- Reduces cognitive load: reader knows when action happens
+
+**When to use**: If a condition needs comments to clarify what it means, rewrite as positive.
+
 ## Problem-Solving Process
 
 ### 1. Periodically Stop and Verify
@@ -187,6 +199,17 @@ See "Working with the Slang Library" section above for detailed case study.
 See `docs/SEMANTIC_INDEXING.md` for details on symmetric expression storage pattern.
 
 **Pattern**: Store expressions alongside computed values for LSP access without re-evaluation.
+
+### Interface Instance Deduplication
+
+Interfaces are fully elaborated when nested in modules, creating duplicate instances pointing to same syntax. Check parent scope to distinguish standalone (parent=CompilationUnit) vs nested. Only traverse standalone instances.
+
+**Pattern**: Use positive conditions to express intent directly.
+
+**Key files**:
+
+- `slangd/include/slangd/semantic/semantic_index.hpp:185`: Handler declaration
+- `slangd/src/slangd/semantic/semantic_index.cpp:1549-1570`: Parent scope check
 
 ## For AI Agents and Junior Engineers
 

--- a/docs/SEMANTIC_INDEXING.md
+++ b/docs/SEMANTIC_INDEXING.md
@@ -106,19 +106,7 @@ case SK::MySymbol:
 
 ### 2. Self-Definition Handler
 
-Add handler method to enable go-to-definition on the symbol itself:
-
-```cpp
-void IndexVisitor::handle(const MySymbol& symbol) {
-  if (const auto* syntax = symbol.getSyntax()) {
-    if (syntax->kind == SyntaxKind::MyDeclaration) {
-      auto range = syntax->as<MyDeclarationSyntax>().name.range();
-      CreateReference(range, range, symbol);
-    }
-  }
-  this->visitDefault(symbol);  // Always call to continue traversal
-}
-```
+Use `AddDefinition()` to create symbol definitions. For end labels (e.g., `endmodule : Test`), use `AddReference()` with `syntax->endBlockName->name.range()`.
 
 ### 3. Reference Handler
 

--- a/include/slangd/semantic/semantic_index.hpp
+++ b/include/slangd/semantic/semantic_index.hpp
@@ -165,6 +165,7 @@ class SemanticIndex {
     void handle(const slang::ast::HierarchicalValueExpression& expr);
 
     // Symbol handlers
+    void handle(const slang::ast::FormalArgumentSymbol& formal_arg);
     void handle(const slang::ast::VariableSymbol& symbol);
     void handle(const slang::ast::WildcardImportSymbol& import_symbol);
     void handle(const slang::ast::ExplicitImportSymbol& import_symbol);

--- a/include/slangd/semantic/semantic_index.hpp
+++ b/include/slangd/semantic/semantic_index.hpp
@@ -250,6 +250,12 @@ class SemanticIndex {
     void IndexClassParameters(
         const slang::ast::ClassType& class_type,
         const slang::syntax::ParameterValueAssignmentSyntax& params);
+
+    // Helper for indexing package names in scoped references
+    // (e.g., pkg::PARAM, pkg::func())
+    void IndexPackageInScopedName(
+        const slang::syntax::SyntaxNode* syntax,
+        const slang::ast::Symbol& target_symbol);
   };
 };
 

--- a/include/slangd/semantic/semantic_index.hpp
+++ b/include/slangd/semantic/semantic_index.hpp
@@ -182,6 +182,7 @@ class SemanticIndex {
     void handle(const slang::ast::InterfacePortSymbol& interface_port);
     void handle(const slang::ast::ModportSymbol& modport);
     void handle(const slang::ast::ModportPortSymbol& modport_port);
+    void handle(const slang::ast::InstanceSymbol& instance);
     void handle(const slang::ast::GenerateBlockArraySymbol& generate_array);
     void handle(const slang::ast::GenerateBlockSymbol& generate_block);
     void handle(const slang::ast::GenvarSymbol& genvar);

--- a/src/slangd/semantic/semantic_index.cpp
+++ b/src/slangd/semantic/semantic_index.cpp
@@ -1088,6 +1088,14 @@ void SemanticIndex::IndexVisitor::handle(
           AddDefinition(
               subroutine, subroutine.name, definition_range,
               subroutine.getParentScope());
+
+          // Add reference for end label (e.g., "endfunction : my_func")
+          if (func_syntax.endBlockName != nullptr) {
+            AddReference(
+                subroutine, subroutine.name,
+                func_syntax.endBlockName->name.range(), definition_range,
+                subroutine.getParentScope());
+          }
         }
       }
     }
@@ -1108,6 +1116,13 @@ void SemanticIndex::IndexVisitor::handle(
         AddDefinition(
             definition, definition.name, definition_range,
             definition.getParentScope());
+
+        // Add reference for end label (e.g., "endmodule : Test")
+        if (decl_syntax.blockName != nullptr) {
+          AddReference(
+              definition, definition.name, decl_syntax.blockName->name.range(),
+              definition_range, definition.getParentScope());
+        }
       }
     }
   }
@@ -1240,6 +1255,14 @@ void SemanticIndex::IndexVisitor::handle(
         AddDefinition(
             class_def, class_def.name, definition_range,
             class_def.getParentScope(), class_type_scope);
+
+        // Add reference for end label (e.g., "endclass : MyClass")
+        if (class_syntax.endBlockName != nullptr) {
+          AddReference(
+              class_def, class_def.name,
+              class_syntax.endBlockName->name.range(), definition_range,
+              class_def.getParentScope());
+        }
       }
     }
 
@@ -1322,6 +1345,14 @@ void SemanticIndex::IndexVisitor::handle(
         AddDefinition(
             class_type, class_type.name, definition_range,
             class_type.getParentScope());
+
+        // Add reference for end label (e.g., "endclass : MyClass")
+        if (class_syntax.endBlockName != nullptr) {
+          AddReference(
+              class_type, class_type.name,
+              class_syntax.endBlockName->name.range(), definition_range,
+              class_type.getParentScope());
+        }
 
         // Index base class reference using stored range from Slang
         if (const auto* base = class_type.getBaseClass()) {
@@ -1586,6 +1617,13 @@ void SemanticIndex::IndexVisitor::handle(
         auto definition_range = decl_syntax.header->name.range();
         AddDefinition(
             package, package.name, definition_range, package.getParentScope());
+
+        // Add reference for end label (e.g., "endpackage : TestPkg")
+        if (decl_syntax.blockName != nullptr) {
+          AddReference(
+              package, package.name, decl_syntax.blockName->name.range(),
+              definition_range, package.getParentScope());
+        }
       }
     }
   }

--- a/src/slangd/semantic/semantic_index.cpp
+++ b/src/slangd/semantic/semantic_index.cpp
@@ -826,10 +826,19 @@ void SemanticIndex::IndexVisitor::handle(
 
 void SemanticIndex::IndexVisitor::handle(
     const slang::ast::ConversionExpression& expr) {
-  // Only process explicit user-written type casts (e.g., type_name'(value))
-  // Skip implicit compiler-generated conversions to avoid duplicates
+  // Only process explicit user-written casts (e.g., type_name'(value) or
+  // NUM'(value)) Skip implicit compiler-generated conversions to avoid
+  // duplicates
   if (!expr.isImplicit()) {
+    // Handle type casts (e.g., typedef_t'(value))
     TraverseType(*expr.type);
+
+    // Handle size casts (e.g., NUM_ENTRIES'(value))
+    // castWidthExpr stores the width expression (NUM_ENTRIES) for LSP
+    // navigation
+    if (const auto* width_expr = expr.getCastWidthExpr()) {
+      width_expr->visit(*this);
+    }
   }
   this->visitDefault(expr);
 }

--- a/test/slangd/semantic/definition/class_definition_test.cpp
+++ b/test/slangd/semantic/definition/class_definition_test.cpp
@@ -29,11 +29,12 @@ TEST_CASE("SemanticIndex class self-definition works", "[definition]") {
   SimpleTestFixture fixture;
   std::string code = R"(
     class Counter;
-    endclass
+    endclass : Counter
   )";
 
   auto index = fixture.CompileSource(code);
   fixture.AssertGoToDefinition(*index, code, "Counter", 0, 0);
+  fixture.AssertGoToDefinition(*index, code, "Counter", 1, 0);
 }
 
 TEST_CASE("SemanticIndex class reference in variable works", "[definition]") {

--- a/test/slangd/semantic/definition/interface_definition_test.cpp
+++ b/test/slangd/semantic/definition/interface_definition_test.cpp
@@ -115,8 +115,7 @@ TEST_CASE(
   fixture.AssertGoToDefinition(*index, code, "addr", 0, 0);
   fixture.AssertGoToDefinition(*index, code, "data", 0, 0);
   fixture.AssertGoToDefinition(*index, code, "cpu", 0, 0);
-  // fixture.AssertGoToDefinition(*index, code, "addr", 1, 0);  // TODO: Member
-  // access in expression
+  fixture.AssertGoToDefinition(*index, code, "addr", 1, 0);
   // TODO: Interface member access (mem_if.addr) not yet indexed
 }
 

--- a/test/slangd/semantic/definition/interface_definition_test.cpp
+++ b/test/slangd/semantic/definition/interface_definition_test.cpp
@@ -111,10 +111,30 @@ TEST_CASE(
   fixture.AssertGoToDefinition(*index, code, "MemBus", 0, 0);
   fixture.AssertGoToDefinition(*index, code, "mem_if", 0, 0);
   fixture.AssertGoToDefinition(*index, code, "MemBus", 1, 0);
-  fixture.AssertGoToDefinition(*index, code, "cpu", 1, 0);
+  // fixture.AssertGoToDefinition(*index, code, "cpu", 1, 0);  // TODO: Modport
+  // reference
   fixture.AssertGoToDefinition(*index, code, "addr", 0, 0);
   fixture.AssertGoToDefinition(*index, code, "data", 0, 0);
   fixture.AssertGoToDefinition(*index, code, "cpu", 0, 0);
-  fixture.AssertGoToDefinition(*index, code, "addr", 1, 0);
+  // fixture.AssertGoToDefinition(*index, code, "addr", 1, 0);  // TODO: Member
+  // access in expression
   // TODO: Interface member access (mem_if.addr) not yet indexed
+}
+
+TEST_CASE(
+    "SemanticIndex interface parameter in packed dimension works",
+    "[definition]") {
+  SimpleTestFixture fixture;
+  std::string code = R"(
+    interface test_if #(
+      parameter int WIDTH = 8
+    ) ();
+      logic [WIDTH-1:0] data_signal;
+    endinterface
+  )";
+
+  auto index = fixture.CompileSource(code);
+
+  fixture.AssertGoToDefinition(*index, code, "WIDTH", 0, 0);
+  fixture.AssertGoToDefinition(*index, code, "WIDTH", 1, 0);
 }

--- a/test/slangd/semantic/definition/interface_definition_test.cpp
+++ b/test/slangd/semantic/definition/interface_definition_test.cpp
@@ -25,6 +25,18 @@ auto main(int argc, char* argv[]) -> int {
 
 using slangd::test::SimpleTestFixture;
 
+TEST_CASE("SemanticIndex interface end label reference works", "[definition]") {
+  SimpleTestFixture fixture;
+  std::string code = R"(
+    interface TestIf;
+    endinterface : TestIf
+  )";
+
+  auto index = fixture.CompileSource(code);
+  fixture.AssertGoToDefinition(*index, code, "TestIf", 0, 0);
+  fixture.AssertGoToDefinition(*index, code, "TestIf", 1, 0);
+}
+
 TEST_CASE(
     "SemanticIndex interface modport self-definition works", "[definition]") {
   SimpleTestFixture fixture;

--- a/test/slangd/semantic/definition/interface_definition_test.cpp
+++ b/test/slangd/semantic/definition/interface_definition_test.cpp
@@ -9,7 +9,7 @@
 
 #include "../../common/simple_fixture.hpp"
 
-constexpr auto kLogLevel = spdlog::level::debug;  // Always debug for tests
+constexpr auto kLogLevel = spdlog::level::debug;
 
 auto main(int argc, char* argv[]) -> int {
   spdlog::set_level(kLogLevel);
@@ -111,8 +111,7 @@ TEST_CASE(
   fixture.AssertGoToDefinition(*index, code, "MemBus", 0, 0);
   fixture.AssertGoToDefinition(*index, code, "mem_if", 0, 0);
   fixture.AssertGoToDefinition(*index, code, "MemBus", 1, 0);
-  // fixture.AssertGoToDefinition(*index, code, "cpu", 1, 0);  // TODO: Modport
-  // reference
+  fixture.AssertGoToDefinition(*index, code, "cpu", 1, 0);
   fixture.AssertGoToDefinition(*index, code, "addr", 0, 0);
   fixture.AssertGoToDefinition(*index, code, "data", 0, 0);
   fixture.AssertGoToDefinition(*index, code, "cpu", 0, 0);

--- a/test/slangd/semantic/definition/net_definition_test.cpp
+++ b/test/slangd/semantic/definition/net_definition_test.cpp
@@ -9,7 +9,7 @@
 
 #include "../../common/simple_fixture.hpp"
 
-constexpr auto kLogLevel = spdlog::level::debug;  // Always debug for tests
+constexpr auto kLogLevel = spdlog::level::debug;
 
 auto main(int argc, char* argv[]) -> int {
   spdlog::set_level(kLogLevel);
@@ -55,7 +55,7 @@ TEST_CASE(
       supply0 gnd;
       supply1 vdd;
       wire result;
-      
+
       // Net usage in assign statements
       assign bus_data = 32'h1234;
       assign tri_signal = bus_data[15:0];
@@ -81,11 +81,11 @@ TEST_CASE("SemanticIndex complex net expressions work", "[definition]") {
       wire [7:0] addr;
       tri enable;
       supply0 gnd;
-      
+
       // Complex expressions with multiple net references
       assign data_out = enable ? data_in : 32'h0;
       assign addr = data_in[7:0] & 8'hFF;
-      
+
       // Nested expressions
       wire intermediate;
       assign intermediate = (data_in != 32'h0) && enable;
@@ -115,12 +115,12 @@ TEST_CASE("SemanticIndex multiple net declarations work", "[definition]") {
       wire a, b, c;
       tri [7:0] x, y, z;
       supply0 gnd0, gnd1;
-      
+
       // References to each net
       assign a = 1'b1;
       assign b = a;
       assign c = b;
-      
+
       assign x = 8'h01;
       assign y = x + 1;
       assign z = y & 8'hF0;

--- a/test/slangd/semantic/definition/scope_definition_test.cpp
+++ b/test/slangd/semantic/definition/scope_definition_test.cpp
@@ -25,6 +25,30 @@ auto main(int argc, char* argv[]) -> int {
 
 using slangd::test::SimpleTestFixture;
 
+TEST_CASE("SemanticIndex module end label reference works", "[definition]") {
+  SimpleTestFixture fixture;
+  std::string code = R"(
+    module Test;
+    endmodule : Test
+  )";
+
+  auto index = fixture.CompileSource(code);
+  fixture.AssertGoToDefinition(*index, code, "Test", 0, 0);
+  fixture.AssertGoToDefinition(*index, code, "Test", 1, 0);
+}
+
+TEST_CASE("SemanticIndex package end label reference works", "[definition]") {
+  SimpleTestFixture fixture;
+  std::string code = R"(
+    package TestPkg;
+    endpackage : TestPkg
+  )";
+
+  auto index = fixture.CompileSource(code);
+  fixture.AssertGoToDefinition(*index, code, "TestPkg", 0, 0);
+  fixture.AssertGoToDefinition(*index, code, "TestPkg", 1, 0);
+}
+
 TEST_CASE("SemanticIndex wildcard import reference works", "[definition]") {
   SimpleTestFixture fixture;
   std::string code = R"(

--- a/test/slangd/semantic/definition/scope_definition_test.cpp
+++ b/test/slangd/semantic/definition/scope_definition_test.cpp
@@ -9,7 +9,7 @@
 
 #include "../../common/simple_fixture.hpp"
 
-constexpr auto kLogLevel = spdlog::level::debug;  // Always debug for tests
+constexpr auto kLogLevel = spdlog::level::debug;
 
 auto main(int argc, char* argv[]) -> int {
   spdlog::set_level(kLogLevel);

--- a/test/slangd/semantic/definition/scope_definition_test.cpp
+++ b/test/slangd/semantic/definition/scope_definition_test.cpp
@@ -377,3 +377,81 @@ TEST_CASE(
   fixture.AssertGoToDefinition(*index, code, "signal_c", 0, 0);
   fixture.AssertGoToDefinition(*index, code, "signal_default", 0, 0);
 }
+
+TEST_CASE("SemanticIndex package name in function call works", "[definition]") {
+  SimpleTestFixture fixture;
+  std::string code = R"(
+    package util_pkg;
+      function automatic bit is_valid(int val);
+        return val > 0;
+      endfunction
+    endpackage
+
+    module test;
+      parameter int SIZE = 10;
+      if (util_pkg::is_valid(SIZE)) begin
+        logic data;
+      end
+    endmodule
+  )";
+
+  auto index = fixture.CompileSource(code);
+  // Test clicking on package name in function call
+  fixture.AssertGoToDefinition(*index, code, "util_pkg", 1, 0);
+}
+
+TEST_CASE(
+    "SemanticIndex package name in parameter reference works", "[definition]") {
+  SimpleTestFixture fixture;
+  std::string code = R"(
+    package cfg_pkg;
+      parameter int BUS_WIDTH = 32;
+    endpackage
+
+    module test;
+      logic [cfg_pkg::BUS_WIDTH-1:0] bus;
+    endmodule
+  )";
+
+  auto index = fixture.CompileSource(code);
+  // Test clicking on package name when accessing parameter
+  fixture.AssertGoToDefinition(*index, code, "cfg_pkg", 1, 0);
+}
+
+TEST_CASE(
+    "SemanticIndex package name in typedef reference works", "[definition]") {
+  SimpleTestFixture fixture;
+  std::string code = R"(
+    package types_pkg;
+      typedef logic [7:0] byte_t;
+    endpackage
+
+    module test;
+      types_pkg::byte_t data;
+    endmodule
+  )";
+
+  auto index = fixture.CompileSource(code);
+  // Test clicking on package name when using typedef
+  fixture.AssertGoToDefinition(*index, code, "types_pkg", 1, 0);
+}
+
+TEST_CASE(
+    "SemanticIndex package name in class reference works", "[definition]") {
+  SimpleTestFixture fixture;
+  std::string code = R"(
+    package class_pkg;
+      class Transaction;
+        int id;
+      endclass
+    endpackage
+
+    module test;
+      class_pkg::Transaction txn;
+    endmodule
+  )";
+
+  auto index = fixture.CompileSource(code);
+  // Test clicking on package name when using class type
+  fixture.AssertGoToDefinition(*index, code, "class_pkg", 1, 0);
+}

--- a/test/slangd/semantic/definition/subroutine_definition_test.cpp
+++ b/test/slangd/semantic/definition/subroutine_definition_test.cpp
@@ -31,7 +31,7 @@ TEST_CASE("SemanticIndex task go-to-definition works", "[definition]") {
     module task_test;
       task my_task(input int a, output int b);
         b = a + 1;
-      endtask
+      endtask : my_task
 
       initial begin
         int result;
@@ -42,11 +42,9 @@ TEST_CASE("SemanticIndex task go-to-definition works", "[definition]") {
 
   auto index = fixture.CompileSource(code);
 
-  // Test self-definition (clicking on task declaration)
   fixture.AssertGoToDefinition(*index, code, "my_task", 0, 0);
-
-  // Test call reference (clicking on task call)
   fixture.AssertGoToDefinition(*index, code, "my_task", 1, 0);
+  fixture.AssertGoToDefinition(*index, code, "my_task", 2, 0);
 }
 
 TEST_CASE("SemanticIndex task argument reference works", "[definition]") {
@@ -71,7 +69,7 @@ TEST_CASE("SemanticIndex function go-to-definition works", "[definition]") {
     module function_test;
       function int my_function(input int x);
         return x * 2;
-      endfunction
+      endfunction : my_function
 
       initial begin
         $display("Result: %d", my_function(5));
@@ -81,11 +79,9 @@ TEST_CASE("SemanticIndex function go-to-definition works", "[definition]") {
 
   auto index = fixture.CompileSource(code);
 
-  // Test self-definition (clicking on function declaration)
   fixture.AssertGoToDefinition(*index, code, "my_function", 0, 0);
-
-  // Test call reference (clicking on function call)
   fixture.AssertGoToDefinition(*index, code, "my_function", 1, 0);
+  fixture.AssertGoToDefinition(*index, code, "my_function", 2, 0);
 }
 
 TEST_CASE("SemanticIndex function argument reference works", "[definition]") {

--- a/test/slangd/semantic/definition/subroutine_definition_test.cpp
+++ b/test/slangd/semantic/definition/subroutine_definition_test.cpp
@@ -223,10 +223,15 @@ TEST_CASE(
   )";
 
   auto index = fixture.CompileSource(code);
+  // Type references should go to typedef definitions
   fixture.AssertGoToDefinition(*index, code, "byte_t", 0, 0);
   fixture.AssertGoToDefinition(*index, code, "byte_t", 1, 0);
   fixture.AssertGoToDefinition(*index, code, "packet_t", 0, 0);
   fixture.AssertGoToDefinition(*index, code, "packet_t", 1, 0);
+
+  // Formal argument names should have self-references
+  fixture.AssertGoToDefinition(*index, code, "data", 0, 0);
+  fixture.AssertGoToDefinition(*index, code, "pkt", 0, 0);
 }
 
 TEST_CASE("SemanticIndex task argument type reference works", "[definition]") {
@@ -242,6 +247,12 @@ TEST_CASE("SemanticIndex task argument type reference works", "[definition]") {
   )";
 
   auto index = fixture.CompileSource(code);
+  // Type references should go to typedef definition
   fixture.AssertGoToDefinition(*index, code, "counter_t", 0, 0);
   fixture.AssertGoToDefinition(*index, code, "counter_t", 1, 0);
+
+  // Formal argument name should have self-reference
+  // Note: cnt appears 3 times (declaration, then 2 uses in body)
+  // The first occurrence (index 0) should go to itself
+  fixture.AssertGoToDefinition(*index, code, "cnt", 0, 0);
 }

--- a/test/slangd/semantic/definition/type_definition_test.cpp
+++ b/test/slangd/semantic/definition/type_definition_test.cpp
@@ -63,10 +63,10 @@ TEST_CASE(
   SimpleTestFixture fixture;
   std::string code = R"(
     typedef struct packed { logic [7:0] x, y; } complex_t;
-    
+
     module complex_test;
       complex_t result;
-      
+
       always_comb begin
         result = complex_t'(16'h1234);
       end
@@ -75,6 +75,24 @@ TEST_CASE(
 
   auto index = fixture.CompileSource(code);
   fixture.AssertGoToDefinition(*index, code, "complex_t", 1, 0);
+}
+
+TEST_CASE(
+    "SemanticIndex constant size cast reference lookup works", "[definition]") {
+  SimpleTestFixture fixture;
+  std::string code = R"(
+    module sizecast_test;
+      parameter WIDTH = 8;
+      logic [7:0] result;
+
+      always_comb begin
+        result = WIDTH'(4);
+      end
+    endmodule
+  )";
+
+  auto index = fixture.CompileSource(code);
+  fixture.AssertGoToDefinition(*index, code, "WIDTH", 1, 0);
 }
 
 TEST_CASE(

--- a/test/slangd/semantic/definition/variable_definition_test.cpp
+++ b/test/slangd/semantic/definition/variable_definition_test.cpp
@@ -9,7 +9,7 @@
 
 #include "../../common/simple_fixture.hpp"
 
-constexpr auto kLogLevel = spdlog::level::debug;  // Always debug for tests
+constexpr auto kLogLevel = spdlog::level::debug;
 
 auto main(int argc, char* argv[]) -> int {
   spdlog::set_level(kLogLevel);


### PR DESCRIPTION
## Summary

This PR adds comprehensive go-to-definition support for several previously missing SystemVerilog language features, enabling LSP navigation across package imports, function/task arguments, interface modports, end labels, and type casts.

## Key Changes

### Package Import Navigation
- **Package name resolution**: Enable go-to-definition on package names in scoped references (`pkg::item`)
- **Scoped name handling**: Add `IndexPackageInScopedName` helper to extract package identifiers
- **Wide coverage**: Support package references in function calls, named values, and type references
- **Range optimization**: Extract rightmost name part to prevent definition range overlaps

### Function/Task Argument Support
- **Argument variables**: Index formal argument declarations with definition ranges
- **Type references**: Traverse argument types to enable navigation to typedefs/classes
- **Self-references**: Handle `DeclaratorSyntax` for argument variable name navigation
- **Port distinction**: Properly differentiate function/task args (Declarator) from module ports (PortDeclaration)

### Interface Modport Features (Breakthrough Implementation)
- **Eager resolution**: Resolve interface port connections during semantic indexing
- **Symbol caching**: Cache modport symbols in InterfacePortSymbol for LSP features
- **Cross-references**: Create modport name-to-definition mappings
- **Deduplication fix**: Prevent duplicate interface traversal via InstanceSymbol handler
  - Check parent scope to distinguish standalone vs nested interface instances
  - Only traverse interfaces when parent is CompilationUnit (standalone mode)
- **Slang integration**: Updated to f461a43b with modport caching support

### End Label Navigation
- **Scope end labels**: Support modules, interfaces, packages, programs
- **Block end labels**: Support functions, tasks, classes
- **Pattern documentation**: Document end label implementation pattern in SEMANTIC_INDEXING.md

### Type Cast Support
- **Constant size casts**: Enable navigation in `NUM_ENTRIES'(value)` style casts
- **Expression preservation**: Visit `castWidthExpr` in ConversionExpression handler
- **Slang update**: Updated to 8c09a579 with cast expression preservation

## Documentation

- **SEMANTIC_INDEXING.md**: Added patterns for end labels, package imports, modport handling
- **DESIGN_PRINCIPLES.md**: Documented positive condition pattern and interface deduplication strategy
- **CLAUDE.md**: Added source range printing utilities for debugging
- **PR command**: Improved documentation with theme-based organization guidance

## Testing

All new features include comprehensive test coverage:
- Package scoped references (functions, parameters, typedefs, classes)
- Function/task formal arguments (variables and types)
- Interface modport declarations and references
- End labels for all supported scope and block types
- Constant size casts with typedef navigation
- Self-reference patterns for argument variables

All tests passing with 562 insertions, 118 deletions across 14 files.